### PR TITLE
add motd explaining appliance_console cmd

### DIFF
--- a/COPY/etc/motd
+++ b/COPY/etc/motd
@@ -1,0 +1,3 @@
+Welcome to the Appliance Console
+
+For a menu, please type: appliance_console


### PR DESCRIPTION
When users get a console bash shell or an ssh shell, tell them about the `appliance_console` command.

This was pulled out of ManageIQ/manageiq#792
