### PR TITLE
Added logging redirect to evmserver script.

### DIFF
--- a/LINK/bin/evmserver.sh
+++ b/LINK/bin/evmserver.sh
@@ -46,13 +46,13 @@ status() {
 }
 
 update_start() {
-  $RAKE evm:update_start
+  $RAKE evm:update_start >> /var/www/miq/vmdb/log/evm.log 2>&1
   RETVAL=$?
   return $RETVAL
 }
 
 update_stop() {
-  $RAKE evm:update_stop
+  $RAKE evm:update_stop >> /var/www/miq/vmdb/log/evm.log 2>&1
   RETVAL=$?
   return $RETVAL
 }


### PR DESCRIPTION
During the update process evmserver.sh update_start is called from
within a yum posttrans and yum's parent process has already been killed as
a part of server shutdown.
This caused the rake task started by evmserver to be killed when
attempting to write to stdout or stderr.
For this reason the redirect was added for rake tasks in evmserver.sh
that are called during an update.

https://bugzilla.redhat.com/show_bug.cgi?id=1239035
