### PR TITLE
display the product name and ip at appliance login

### DIFF
--- a/COPY/etc/NetworkManager/dispatcher.d/99-fix-issue
+++ b/COPY/etc/NetworkManager/dispatcher.d/99-fix-issue
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# bail unless ($1 = eth0 && $2 = up) || ($1 = eth0 && $2 = hostname)
+# dont call exit
+if [ "$1" != "eth0" -o "$2" != "up" -a "$2" != "hostname" ] ; then
+  :
+else
+  # After a network interface is loaded
+  # this updates the /etc/issue file to show the ip address
+  # and product name
+
+  # extract PRODUCT from en:product:name
+  PRODUCT=sed -n ':a;N;s/\([ ]*product:\n[ ]*name: \)//p' /var/www/miq/vmdb/config/locales/en.yml
+  IP=`hostname -I | cut -d' ' -f1`
+
+  # replace \p with the product name
+  # replace \i with the ip address
+
+  sed /etc/issue.template -e "s/\\\\P/${PRODUCT}/g" -e "s/\\\\i/${IP}/g" > /etc/issue
+  cp /etc/issue /etc/issue.net
+fi

--- a/COPY/etc/issue.template
+++ b/COPY/etc/issue.template
@@ -1,0 +1,6 @@
+Welcome to the \P Virtual Appliance.
+
+You can browse to http://\i/ or http://\n/
+
+\S
+Kernel \r on an \m


### PR DESCRIPTION
**Problem:**

The prompt on the appliance used to display the ip address.
Now that we are using `getty`, that is no longer displayed.

**Solution:**

Display the product name and ip address in the `getty` screen using the standard `/etc/issue` and `/etc/issue.net` mechanism.

Since standard `getty` does not have the ability to display an ip address (or the product name). This PR uses a script to add those elements.

**Outstanding:**

I was not able to easily parse the yaml locale file. I have hardcoded `"ManageIQ"` for now. I'm fine punting for now, let me know if you have a solution or concern punting on this. Alternatively, we can reword so "ManageIQ" / "CFME" is not displayed.

---

Visuals

CentOS 6.5:
<img width="303" alt="miq54-20150129 way before" src="https://cloud.githubusercontent.com/assets/1930/8624714/0cb40e84-2708-11e5-8267-f0721e4eec4f.png">

Now:
<img width="216" alt="miq54-20150608 before" src="https://cloud.githubusercontent.com/assets/1930/8624666/b19d3f20-2707-11e5-9e34-2db1b006b787.png">

After PR:
<img width="312" alt="miq56-20150709 2015-07-10 13-36-13" src="https://cloud.githubusercontent.com/assets/1930/8624816/b76ae096-2708-11e5-9b84-2e8e9e07306b.png">

/cc @abellotti made the request, although I know he will not be here to verify
/cc @dmetzger57 @carbonin This look good / you have an alternative implementation
/cc @Fryguy @chessbyte minor but is the last bit to make this similar to 
