### PR TITLE
Added restorecon to restore SELinux contexts to file default after mv

### DIFF
--- a/LINK/bin/miqnet.sh
+++ b/LINK/bin/miqnet.sh
@@ -164,6 +164,7 @@ set_hostname() {
   if [ $? -eq 0 ]; then
     sed "s/\(^${IP_ADDR}\>\s*\)\(.*\<.*$\)/\1${1}/" /etc/hosts > /etc/hosts.new
     mv /etc/hosts.new /etc/hosts
+    restorecon /etc/hosts
   else
     echo -e "${IP_ADDR}\t\t${1}" >> /etc/hosts
   fi
@@ -244,6 +245,7 @@ set_static () {
     echo nameserver $5 >> /etc/resolv.conf.new
   fi
   mv /etc/resolv.conf.new /etc/resolv.conf
+  restorecon /etc/resolv.conf
   log "set_static: resolve new: $(cat /etc/resolv.conf)"
 }
 
@@ -279,6 +281,7 @@ GATEWAY=${3}
 NM_CONTROLLED=no
 DNS1=${4}" >> ${cfg}.tmp
   mv ${cfg}.tmp $cfg
+  restorecon $cfg
   log "set_redhat_static: cfg new: $(cat ${cfg})"
 
   # Truncate the temporary io file
@@ -294,6 +297,7 @@ DNS1=${4}" >> ${cfg}.tmp
     log "set_redhat_static: ifup eth0 failed due to error: $(cat $ERR_FILE)...reloading from backup"
     # Restore from backup and exit
     mv ${cfg}.bak $cfg
+    restorecon $cfg
     systemctl restart network > /dev/null 2>&1
     ifup eth0 > /dev/null 2>&1
     echo "Unable to set static network configuration." >&2
@@ -310,6 +314,7 @@ DNS1=${4}" >> ${cfg}.tmp
   echo "NETWORKING=yes
 GATEWAY=${3}" >> ${network}.tmp
   mv ${network}.tmp $network
+  restorecon $network
   log "set_redhat_static: network cfg new: $(cat ${network})"
   log "set_redhat_static: route old: $(route)"
 
@@ -339,6 +344,7 @@ GATEWAY=${3}" >> ${network}.tmp
     # Change the ip associated with the hostname to the new ip
     sed "s/\(^$old_ip\)\(\>\s*.*\<.*$\)/$1\2/" /etc/hosts > /etc/hosts.new
     mv /etc/hosts.new /etc/hosts
+    restorecon /etc/hosts
   else
     # Add a line with the new ip and the existing hostname
     echo -e "$1\t\t$hn" >> /etc/hosts
@@ -367,6 +373,7 @@ set_search_order() {
   grep -v -E "^search" /etc/resolv.conf > /etc/resolv.conf.new
   echo "search $new_order" >> /etc/resolv.conf.new
   mv /etc/resolv.conf.new /etc/resolv.conf
+  restorecon /etc/resolv.conf
   log "set_search_order: resolve new: $(cat /etc/resolv.conf)"
 }
 
@@ -381,6 +388,7 @@ set_dhcp() {
   log "set_dhcp: resolve old: $(cat /etc/resolv.conf)"
   grep -v -E "^(nameserver|search)" /etc/resolv.conf > /etc/resolv.conf.new
   mv /etc/resolv.conf.new /etc/resolv.conf
+  restorecon /etc/resolv.conf
 
   set_${DISTRO}_dhcp "$@"
   log "set_dhcp: resolve new: $(cat /etc/resolv.conf)"
@@ -407,12 +415,14 @@ set_redhat_dhcp() {
   # append the temp file with the data we are replacing
   echo "BOOTPROTO=dhcp" >> ${cfg}.tmp
   mv ${cfg}.tmp $cfg
+  restorecon $cfg
   log "set_redhat_dhcp: cfg new: $(cat ${cfg})"
   log "set_redhat_dhcp: network old: $(cat ${network})"
   # 2) Remove the GATEWAY lines in /etc/sysconfig/network
   cat $network | grep -v -E "^(NETWORKING|GATEWAY)" > ${network}.tmp
   echo "NETWORKING=yes" >> ${network}.tmp
   mv ${network}.tmp $network
+  restorecon $network
   log "set_redhat_dhcp: network new: $(cat ${network})"
 
   log "set_redhat_dhcp: route old: $(route)"
@@ -436,6 +446,7 @@ set_redhat_dhcp() {
     # Restore from backup and exit
     ifdown eth0 > /dev/null 2>&1
     mv ${cfg}.bak $cfg
+    restorecon $cfg
     ifup eth0 > /dev/null 2>&1
     echo "Unable to set DHCP network configuration." >&2
     exit 1
@@ -462,6 +473,7 @@ set_redhat_dhcp() {
     # Change the ip associated with the hostname to the new ip
     sed "s/\(^$old_ip\)\(\>\s*.*\<.*$\)/$new_ip\2/" /etc/hosts > /etc/hosts.new
     mv /etc/hosts.new /etc/hosts
+    restorecon /etc/hosts
   else
     # Add a line with the new ip and the existing hostname
     echo -e "$new_ip\t\t$hn" >> /etc/hosts

--- a/LINK/bin/miqnet.sh
+++ b/LINK/bin/miqnet.sh
@@ -287,8 +287,6 @@ DNS1=${4}" >> ${cfg}.tmp
   # Truncate the temporary io file
   :> $TMP_IO
 
-  /sbin/restorecon -R /etc/sysconfig
-
   # 2) reload config and bring up the interface to see if it worked
   systemctl restart network > /dev/null 2>> $ERR_FILE
   ifup eth0 >> $TMP_IO 2 >> $ERR_FILE
@@ -435,8 +433,6 @@ set_redhat_dhcp() {
 
   # Truncate the temporary io file
   :> $TMP_IO
-
-  /sbin/restorecon -R /etc/sysconfig
 
   # 4) Start the interface to see if it worked
   ifup eth0 >> $TMP_IO 2>> $ERR_FILE


### PR DESCRIPTION
The mv command will take the SELinux contexts from the source file
when overwriting an existing one.
This was the primary way files were changed in the miqnet.sh script.
A new file, created by root, will most likely have different contexts
than the default for the file being edited.
This was causing NetworkManager to fail to write DNS servers retrieved
from the DHCP server to resolv.conf after we had previously edited it.

https://bugzilla.redhat.com/show_bug.cgi?id=1133554
