### PR TITLE
Remove deprecated NameVirtualHost directive from cfme-https.conf

### DIFF
--- a/COPY/etc/httpd/conf.d/cfme-https.conf
+++ b/COPY/etc/httpd/conf.d/cfme-https.conf
@@ -3,7 +3,6 @@
 LoadModule ssl_module modules/mod_ssl.so
 
 Listen 443
-NameVirtualHost *:443
 
 AddType application/x-x509-ca-cert .crt
 AddType application/x-pkcs7-crl    .crl


### PR DESCRIPTION
Has no effect in version 2.4 (http://httpd.apache.org/docs/2.4/mod/core.html#namevirtualhost)

https://trello.com/c/YZjubIFd
