### PR TITLE
Allow the appliance repo to live anywhere by exposing its location.

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -25,8 +25,8 @@ export QPID_SSL_CERT_DB=/etc/qpid/certs
 # Location of certificates and provider keys
 export KEY_ROOT=/var/www/miq/vmdb/certs
 
-export APPLIANCE_REPO_DIRECTORY=/opt/manageiq/manageiq-appliance
-export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_REPO_DIRECTORY}/TEMPLATE
+export APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance
+export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
 
 [[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres

--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -25,6 +25,9 @@ export QPID_SSL_CERT_DB=/etc/qpid/certs
 # Location of certificates and provider keys
 export KEY_ROOT=/var/www/miq/vmdb/certs
 
+export APPLIANCE_REPO_DIRECTORY=/opt/manageiq/manageiq-appliance
+export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_REPO_DIRECTORY}/TEMPLATE
+
 [[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
 [[ -s /opt/rh/nodejs010/enable ]] && source /opt/rh/nodejs010/enable

--- a/LINK/etc/profile.d/evm.sh
+++ b/LINK/etc/profile.d/evm.sh
@@ -2,4 +2,4 @@
 
 # Aliases:
 alias vmdb='cd /var/www/miq/vmdb'
-alias appliance='[[ -n ${APPLIANCE_REPO_DIRECTORY} ]] && cd ${APPLIANCE_REPO_DIRECTORY}'
+alias appliance='[[ -n ${APPLIANCE_SOURCE_DIRECTORY} ]] && cd ${APPLIANCE_SOURCE_DIRECTORY}'

--- a/LINK/etc/profile.d/evm.sh
+++ b/LINK/etc/profile.d/evm.sh
@@ -2,3 +2,4 @@
 
 # Aliases:
 alias vmdb='cd /var/www/miq/vmdb'
+alias appliance='[[ -n ${APPLIANCE_REPO_DIRECTORY} ]] && cd ${APPLIANCE_REPO_DIRECTORY}'


### PR DESCRIPTION
We need to move the manageiq-appliance repo on the appliances so let's
expose it's contents' location via environment variables.

Related PRs:
- https://github.com/ManageIQ/manageiq-appliance-build/pull/33 [ clone repo in new location ] 
- https://github.com/ManageIQ/manageiq-appliance/pull/12  [set environment variable for new location]
- https://github.com/ManageIQ/manageiq/pull/4105 [use environment variable above] 
