### PR TITLE
[WIP]Decrease timeout for cloud-init metadata search

### DIFF
--- a/COPY/etc/cloud/cloud.cfg.d/miq-datasources.cfg
+++ b/COPY/etc/cloud/cloud.cfg.d/miq-datasources.cfg
@@ -1,0 +1,7 @@
+datasource:
+  Ec2:
+    timeout: 5
+    max_wait: 20
+  CloudStack:
+    timeout: 5
+    max_wait: 20

--- a/cfme-setup.sh
+++ b/cfme-setup.sh
@@ -29,6 +29,10 @@ EOF
 [[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "s/handlers=consoleHandler,cloudLogHandler/handlers=cloudLogHandler/g" /etc/cloud/cloud.cfg.d/05_logging.cfg
 [[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "/^ - \[ \*log_base, \*log_syslog \]/d" /etc/cloud/cloud.cfg.d/05_logging.cfg
 [[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "s/^output:.*$/output: {all: '| tee -a \/var\/log\/cloud-init-output\.log \&> \/dev\/null'}/g" /etc/cloud/cloud.cfg.d/05_logging.cfg
+[[ -s /usr/lib/systemd/system/cloud-config.service ]] && sed -i "s/^StandardOutput=.*/StandardOutput=journal/g" /usr/lib/systemd/system/cloud-config.service
+[[ -s /usr/lib/systemd/system/cloud-final.service ]] && sed -i "s/^StandardOutput=.*/StandardOutput=journal/g" /usr/lib/systemd/system/cloud-final.service
+[[ -s /usr/lib/systemd/system/cloud-init-local.service ]] && sed -i "s/^StandardOutput=.*/StandardOutput=journal/g" /usr/lib/systemd/system/cloud-init-local.service
+[[ -s /usr/lib/systemd/system/cloud-init.service ]] && sed -i "s/^StandardOutput=.*/StandardOutput=journal/g" /usr/lib/systemd/system/cloud-init.service
 
 /usr/sbin/semanage fcontext -a -t httpd_log_t "/var/www/miq/vmdb/log(/.*)?"
 /usr/sbin/semanage fcontext -a -t cert_t "/var/www/miq/vmdb/certs(/.*)?"


### PR DESCRIPTION
Added a configuration file which sets the max wait time for the running metadata modules to 20 seconds each.
In version 0.7.6 of cloud-init the ssh daemon is not allowed to start until cloud-init runs in order to prevent a race condition described here https://bugs.launchpad.net/cloud-init/+bug/1333920
The previous value was 120 seconds which was an unacceptably long time to wait for ssh access for someone not using cloud-init (where we would hit the timeout every time it runs). 
