### PR TITLE
Add cloud init datasources script

### DIFF
--- a/COPY/etc/cloud/cloud.cfg.d/miq_cloud.cfg
+++ b/COPY/etc/cloud/cloud.cfg.d/miq_cloud.cfg
@@ -1,0 +1,4 @@
+disable_root: false
+ssh_pwauth: True
+
+users: []

--- a/COPY/usr/lib/systemd/system/cloud-ds-check.service
+++ b/COPY/usr/lib/systemd/system/cloud-ds-check.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=check for which cloud-init datasources should be used
+Before=cloud-init.service
+After=local-fs.target network.target
+Requires=network.target
+Wants=cloud-init.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/cloud_ds_check.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/LINK/bin/cloud_ds_check.sh
+++ b/LINK/bin/cloud_ds_check.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+curl -I --connect-timeout 2 http://169.254.169.254/2009-04-04/meta-data
+[ "$?" = "0" ] && echo "datasource_list: [ Ec2, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg && exit 0
+
+curl -I --connect-timeout 2 http://169.254.169.254/openstack/latest/meta_data.json
+[ "$?" = "0" ] && echo "datasource_list: [ OpenStack, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg && exit 0
+
+gateway=`route -n | grep "^0\.0\.0\.0.*" | awk '{print $2}'`
+curl -I --connect-timeout 2 "http://$gateway/latest/meta-data"
+[ "$?" = "0" ] && echo "datasource_list: [ CloudStack, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg && exit 0
+
+echo "datasource_list: [ NoCloud, AltCloud, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg

--- a/LINK/bin/cloud_ds_check.sh
+++ b/LINK/bin/cloud_ds_check.sh
@@ -10,4 +10,4 @@ gateway=`route -n | grep "^0\.0\.0\.0.*" | awk '{print $2}'`
 curl -I --connect-timeout 2 "http://$gateway/latest/meta-data"
 [ "$?" = "0" ] && echo "datasource_list: [ CloudStack, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg && exit 0
 
-echo "datasource_list: [ NoCloud, AltCloud, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg
+echo "datasource_list: [ NoCloud, ConfigDrive, AltCloud, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg

--- a/cfme-setup.sh
+++ b/cfme-setup.sh
@@ -21,10 +21,6 @@ cat <<'EOF' > /etc/httpd/conf.d/ssl.conf
 # upgraded.
 EOF
 
-# Alter cloud-init config to allow root ssh access to the appliance
-[[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^ssh_pwauth:.*$/ssh_pwauth: True/g" /etc/cloud/cloud.cfg
-[[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^disable_root:.*$/disable_root: false/g" /etc/cloud/cloud.cfg
-
 # Alter cloud-init logging config to prevent logging to the console
 [[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "s/handlers=consoleHandler,cloudLogHandler/handlers=cloudLogHandler/g" /etc/cloud/cloud.cfg.d/05_logging.cfg
 [[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "/^ - \[ \*log_base, \*log_syslog \]/d" /etc/cloud/cloud.cfg.d/05_logging.cfg


### PR DESCRIPTION
Added a script that will run before cloud-init to determine which datasources should be used based on connectivity to the predetermined addresses used for Ec2, CloudStack, and OpenStack metadata.
This will prevent us from timing out while looking for a connection to those datasources and delaying access to the appliance through ssh.

Also moved our cloud.cfg changes to the cloud.cfg.d directory to prevent our edits from being clobbered when the cloud-init package is updated on the appliance.

Requires https://github.com/ManageIQ/manageiq-appliance-build/pull/56
