### PR TITLE
Move cloud-init log cfg to file

### DIFF
--- a/COPY/etc/cloud/cloud.cfg.d/01_miq_logging.cfg
+++ b/COPY/etc/cloud/cloud.cfg.d/01_miq_logging.cfg
@@ -1,0 +1,59 @@
+## This yaml formated config file handles setting
+## logger information.  The values that are necessary to be set
+## are seen at the bottom.  The top '_log' are only used to remove
+## redundency in a syslog and fallback-to-file case.
+##
+## The 'log_cfgs' entry defines a list of logger configs
+## Each entry in the list is tried, and the first one that
+## works is used.  If a log_cfg list entry is an array, it will
+## be joined with '\n'.
+_log:
+ - &log_base |
+   [loggers]
+   keys=root,cloudinit
+   
+   [handlers]
+   keys=consoleHandler,cloudLogHandler
+   
+   [formatters]
+   keys=simpleFormatter,arg0Formatter
+   
+   [logger_root]
+   level=INFO
+   handlers=cloudLogHandler
+   
+   [logger_cloudinit]
+   level=INFO
+   qualname=cloudinit
+   handlers=
+   propagate=1
+   
+   [handler_consoleHandler]
+   class=StreamHandler
+   level=WARNING
+   formatter=arg0Formatter
+   args=(sys.stderr,)
+   
+   [formatter_arg0Formatter]
+   format=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s
+   
+   [formatter_simpleFormatter]
+   format=[CLOUDINIT] %(filename)s[%(levelname)s]: %(message)s
+ - &log_file |
+   [handler_cloudLogHandler]
+   class=FileHandler
+   level=INFO
+   formatter=arg0Formatter
+   args=('/var/log/cloud-init.log',)
+ - &log_syslog |
+   [handler_cloudLogHandler]
+   class=handlers.SysLogHandler
+   level=INFO
+   formatter=simpleFormatter
+   args=("/dev/log", handlers.SysLogHandler.LOG_USER)
+
+log_cfgs:
+# These will be joined into a string that defines the configuration
+ - [ *log_base, *log_file ]
+
+output: {all: '>> /var/log/cloud-init-output.log'}

--- a/COPY/etc/cloud/cloud.cfg.d/01_miq_logging.cfg
+++ b/COPY/etc/cloud/cloud.cfg.d/01_miq_logging.cfg
@@ -45,12 +45,6 @@ _log:
    level=INFO
    formatter=arg0Formatter
    args=('/var/log/cloud-init.log',)
- - &log_syslog |
-   [handler_cloudLogHandler]
-   class=handlers.SysLogHandler
-   level=INFO
-   formatter=simpleFormatter
-   args=("/dev/log", handlers.SysLogHandler.LOG_USER)
 
 log_cfgs:
 # These will be joined into a string that defines the configuration

--- a/cfme-setup.sh
+++ b/cfme-setup.sh
@@ -21,11 +21,6 @@ cat <<'EOF' > /etc/httpd/conf.d/ssl.conf
 # upgraded.
 EOF
 
-# Alter cloud-init logging config to prevent logging to the console
-[[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "s/handlers=consoleHandler,cloudLogHandler/handlers=cloudLogHandler/g" /etc/cloud/cloud.cfg.d/05_logging.cfg
-[[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "/^ - \[ \*log_base, \*log_syslog \]/d" /etc/cloud/cloud.cfg.d/05_logging.cfg
-[[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "s/^output:.*$/output: {all: '| tee -a \/var\/log\/cloud-init-output\.log \&> \/dev\/null'}/g" /etc/cloud/cloud.cfg.d/05_logging.cfg
-
 /usr/sbin/semanage fcontext -a -t httpd_log_t "/var/www/miq/vmdb/log(/.*)?"
 /usr/sbin/semanage fcontext -a -t cert_t "/var/www/miq/vmdb/certs(/.*)?"
 /usr/sbin/semanage fcontext -a -t logrotate_exec_t ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh


### PR DESCRIPTION
Put a file in `/etc/cloud/cloud.cfg.d` to set up cloud-init logging
instead of editing the file owned by the cloud-init package which
could be reverted on an upgrade.
