### PR TITLE
Remove explicit reference to symlinked system directory

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -7,7 +7,7 @@
   compress
   copytruncate
   prerotate
-    /bin/sh /var/www/miq/system/logrotate_free_space_check.sh $1
+    source /etc/default/evm && /bin/sh ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh $1
   endscript
   lastaction
     /sbin/service httpd reload > /dev/null 2>&1 || true

--- a/LINK/usr/bin/evmserver.sh
+++ b/LINK/usr/bin/evmserver.sh
@@ -13,7 +13,7 @@ cd $BASEDIR
 # Load default environment and variables
 [[ -s "/etc/default/evm" ]] && source "/etc/default/evm"
 
-[[ -x "/var/www/miq/system/initialize_appliance.sh" ]] && /var/www/miq/system/initialize_appliance.sh
+[[ -x "${APPLIANCE_SOURCE_DIRECTORY}/initialize_appliance.sh" ]] && ${APPLIANCE_SOURCE_DIRECTORY}/initialize_appliance.sh
 
 start() {
   $RAKE evm:start


### PR DESCRIPTION
Removed path reference to `logrotate_free_space_check.sh` in log rotate prerotate section.
In an effort to remove the symlink to `/var/www/miq/system` these types of
references should be removed.

@jrafanie @abellotti @simaishi
