### PR TITLE
Fix some lib -> vmdb/gems/pending pathing changes

### DIFF
--- a/LINK/usr/bin/appliance_console
+++ b/LINK/usr/bin/appliance_console
@@ -4,4 +4,4 @@
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 
-ruby /var/www/miq/lib/appliance_console.rb $@
+ruby /var/www/miq/vmdb/gems/pending/appliance_console.rb $@

--- a/LINK/usr/bin/appliance_console_cli
+++ b/LINK/usr/bin/appliance_console_cli
@@ -1,18 +1,15 @@
 #!/usr/bin/env ruby
 
 require "pathname"
-# NOTE: in dev, running in cfme/system/LINK/bin/appliance_console_cli
-ROOT ||= [
-  "/var/www/miq",
-  File.expand_path(File.join(File.dirname(__FILE__), "../../.."))
-].detect { |f| File.exist?(f) }
-RAILS_ROOT ||= Pathname.new("#{ROOT}/vmdb")
 
-ENV['BUNDLE_GEMFILE'] ||= "#{ROOT}/vmdb/Gemfile"
+# Handle development environment by setting up Gemfile and manageiq location
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../manageiq/Gemfile', __dir__)
+ROOT ||= File.dirname(ENV['BUNDLE_GEMFILE'])
+
 require 'bundler'
 Bundler.setup
 
-$LOAD_PATH.push("#{ROOT}/lib")
+$LOAD_PATH.push("#{ROOT}/gems/pending")
 
 require 'appliance_console/cli'
 

--- a/LINK/usr/bin/evm_watchdog.rb
+++ b/LINK/usr/bin/evm_watchdog.rb
@@ -2,7 +2,7 @@
 # description: ManageIQ watchdog application loop
 #
 
-require '/var/www/miq/lib/util/system/evm_watchdog'
+require '/var/www/miq/vmdb/gems/pending/util/system/evm_watchdog'
 
 
 EvmWatchdog.kill_other_watchdogs # To prevent duplicates.

--- a/LINK/usr/bin/evm_watchdog.rb
+++ b/LINK/usr/bin/evm_watchdog.rb
@@ -4,7 +4,6 @@
 
 require '/var/www/miq/vmdb/gems/pending/util/system/evm_watchdog'
 
-
 EvmWatchdog.kill_other_watchdogs # To prevent duplicates.
 sleep(600) # 600s = 10 minute startup delay.
 loop do


### PR DESCRIPTION
Cleanup some locations referencing the old lib directory.

This blocks us from dropping the symlinks in upstream [here](https://github.com/ManageIQ/manageiq-appliance-build/pull/64)
