### PR TITLE
Fixed the log file suffix for vmstat and top logs

### DIFF
--- a/LINK/etc/cron.hourly/miqtimestamp-hourly.cron
+++ b/LINK/etc/cron.hourly/miqtimestamp-hourly.cron
@@ -4,13 +4,13 @@
 
 LOG_DIR=/var/www/miq/vmdb/log
 
-for CMD in top vmstat
+for CMD in "top" "vmstat"
 do
-	LOG_FILE=${LOG_DIR}/${CMD}
+	LOG_FILE="${LOG_DIR}/${CMD}_output.log"
 
 	if [ -e ${LOG_FILE} ]
 	then
-		echo "miqtop: timesync: date time is-> $(date) $(date +%z)" >> ${LOG_FILE}
+		echo -e "\ntimesync: date time is-> $(date) $(date +%z)" >> ${LOG_FILE}
 	fi
 done
 


### PR DESCRIPTION
Also removed unnecessary miqtop log line prefix and added a
new line character to improve formatting

https://bugzilla.redhat.com/show_bug.cgi?id=1271668
