### PR TITLE
Compile the sti loader once at build time after assets.

### DIFF
--- a/cfme-setup.sh
+++ b/cfme-setup.sh
@@ -3,6 +3,7 @@
 
 pushd /var/www/miq/vmdb
   RAILS_ENV=production rake evm:compile_assets
+  rake evm:compile_sti_loader
 popd
 
 # Self Service UI


### PR DESCRIPTION
Requires: https://github.com/ManageIQ/manageiq/pull/4973
From: https://github.com/ManageIQ/manageiq/pull/4912
