### PR TITLE
Make cloud-init datasource detection more sensitive to http error codes

### DIFF
--- a/LINK/usr/bin/cloud_ds_check.sh
+++ b/LINK/usr/bin/cloud_ds_check.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-curl -I --connect-timeout 2 http://169.254.169.254/2009-04-04/meta-data
+curl -ILf --connect-timeout 2 http://169.254.169.254/2009-04-04/meta-data
 [ "$?" = "0" ] && echo "datasource_list: [ Ec2, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg && exit 0
 
-curl -I --connect-timeout 2 http://169.254.169.254/openstack/latest/meta_data.json
+curl -ILf --connect-timeout 2 http://169.254.169.254/openstack/latest/meta_data.json
 [ "$?" = "0" ] && echo "datasource_list: [ OpenStack, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg && exit 0
 
 gateway=`route -n | grep "^0\.0\.0\.0.*" | awk '{print $2}'`
-curl -I --connect-timeout 2 "http://$gateway/latest/meta-data"
+curl -ILf --connect-timeout 2 "http://$gateway/latest/meta-data"
 [ "$?" = "0" ] && echo "datasource_list: [ CloudStack, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg && exit 0
 
 echo "datasource_list: [ NoCloud, ConfigDrive, AltCloud, None ]" > /etc/cloud/cloud.cfg.d/datasources.cfg


### PR DESCRIPTION
Added the -L option which allows curl to follow redirects and the -f
option which makes it return an error when it receives an http error

Fixes #34
