### PR TITLE
Added RewriteRule to redirect SSUI requests for /self_service/* to /self_service

### DIFF
--- a/COPY/etc/httpd/conf.d/cfme-https-application.conf
+++ b/COPY/etc/httpd/conf.d/cfme-https-application.conf
@@ -38,9 +38,9 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 # Redirect favicon.ico
 RewriteEngine On
 <ifmodule mod_rewrite.c>
-  RewriteCond %{REQUEST_URI} ^/favicon\.ico$        [NC]
-  RewriteRule (.*) /assets/favicon.ico              [L,R=301]
-  RewriteRule (^/self_service/login$) /self_service [R=301]
+  RewriteCond %{REQUEST_URI} ^/favicon\.ico$ [NC]
+  RewriteRule (.*) /assets/favicon.ico       [L,R=301]
+  RewriteRule (^/self_service/((?!assets)(?!images)(?!img)(?!styles)(?!js)(?!fonts).+)$) /self_service [R=301]
 </ifmodule>
 
 SetEnvIf User-Agent ".*MSIE.*" \

--- a/COPY/etc/httpd/conf.d/cfme-https-application.conf
+++ b/COPY/etc/httpd/conf.d/cfme-https-application.conf
@@ -38,8 +38,9 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 # Redirect favicon.ico
 RewriteEngine On
 <ifmodule mod_rewrite.c>
-  RewriteCond %{REQUEST_URI} ^/favicon\.ico$ [NC]
-  RewriteRule (.*) /assets/favicon.ico       [L,R=301]
+  RewriteCond %{REQUEST_URI} ^/favicon\.ico$        [NC]
+  RewriteRule (.*) /assets/favicon.ico              [L,R=301]
+  RewriteRule (^/self_service/login$) /self_service [R=301]
 </ifmodule>
 
 SetEnvIf User-Agent ".*MSIE.*" \

--- a/COPY/etc/httpd/conf.d/cfme-https-application.conf
+++ b/COPY/etc/httpd/conf.d/cfme-https-application.conf
@@ -40,7 +40,7 @@ RewriteEngine On
 <ifmodule mod_rewrite.c>
   RewriteCond %{REQUEST_URI} ^/favicon\.ico$ [NC]
   RewriteRule (.*) /assets/favicon.ico       [L,R=301]
-  RewriteRule (^/self_service/((?!assets)(?!images)(?!img)(?!styles)(?!js)(?!fonts).+)$) /self_service [R=301]
+  RewriteRule (^/self_service/(?!(assets|images|img|styles|js|fonts)).+$) /self_service [R=301]</ifmodule>
 </ifmodule>
 
 SetEnvIf User-Agent ".*MSIE.*" \


### PR DESCRIPTION
The code change redirects /self_service/\* to /self_service. It, however, excludes 
- /self_service/assets
- /self_service/images
- /self_service/img
- /self_service/styles
- /self_service/js
- /self_service/fonts
  Those URLs need to be serviced as is by the SSUI app.

This addresses a 404 page when refreshing the SSUI login page.

https://bugzilla.redhat.com/show_bug.cgi?id=1275679
