### PR TITLE
Run pre-rotate script even if source command fails

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -7,7 +7,7 @@
   compress
   copytruncate
   prerotate
-    source /etc/default/evm && /bin/sh ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh $1
+    source /etc/default/evm; /bin/sh ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh $1
   endscript
   lastaction
     /sbin/service httpd reload > /dev/null 2>&1 || true


### PR DESCRIPTION
There are some things that the various files sourced
by /etc/default/evm do that SELinux will prevent based
on the context logrotate runs under. Because of this
we need to source the file in order to set our
environment variables and run the pre-rotate script
regardless of the exit status of the source command.

https://bugzilla.redhat.com/show_bug.cgi?id=1265463
