### PR TITLE
Remove cloud-init's ability to change the appliance hostname

### DIFF
--- a/COPY/etc/cloud/cloud.cfg.d/miq_cloud.cfg
+++ b/COPY/etc/cloud/cloud.cfg.d/miq_cloud.cfg
@@ -1,4 +1,6 @@
 disable_root: false
 ssh_pwauth: True
 
+preserve_hostname: true
+
 users: []


### PR DESCRIPTION
The altered hostname was not included in /etc/hosts
causing us to not be able to resolve it when attempting
to run `MiqSockUtil.getFullyQualifiedDomainName`

The decision was made to disallow cloud-init from
changing the hostname at all as to not conflict with our
existing methods of changing the hostname using the
appliance_console.

What was happening was cloud-init was being told that it was responsible for setting the hostname at first boot (by enabling the set_hostname module, which is in the default config shipped with the package). When this is the case and there is no hostname provided, cloud-init uses the system socket hostname (https://github.com/number5/cloud-init/blob/0.7.6/cloudinit/util.py#L970). In some cases this would return `localhost.localdomain`.  

When this happened the fqdn was retrieved from `/etc/hosts` using the function here (https://github.com/number5/cloud-init/blob/0.7.6/cloudinit/util.py#L863). That function makes the assumption that the first name in the list after the IP address in `/etc/hosts` will always be the fqdn, thus giving us `localhost` as the fqdn for `localhost.localdomain`.
For reference, at this point our `/etc/hosts` file looked like this:

```
::1  localhost  localhost.localdomain  localhost6  localhost6.localdomain6
127.0.0.1  localhost  localhost.localdomain  localhost4  localhost4.localdomain
```

After that we hit the following code path:
https://github.com/number5/cloud-init/blob/0.7.6/cloudinit/sources/__init__.py#L180
https://github.com/number5/cloud-init/blob/0.7.6/cloudinit/sources/__init__.py#L201
(hostname = localhost.localdomain, domain = localdomain)
https://github.com/number5/cloud-init/blob/0.7.6/cloudinit/sources/__init__.py#L206
Which will return `localhost.localdomain.localdomain`.

This string is not in `/etc/hosts` and therefore will not resolve on our appliance.

Our options were either to not let cloud-init set the hostname which can be accomplished by the `preserve_hostname: true` config option (https://github.com/number5/cloud-init/blob/0.7.6/doc/examples/cloud-config.txt#L427) or to allow cloud-init to change the hostname, but also update `/etc/hosts` using the `manage_etc_hosts: localhost` option (https://github.com/number5/cloud-init/blob/0.7.6/doc/examples/cloud-config.txt#L470).

Unfortunately the `manage_etc_hosts: localhost` option makes cloud-init assume it is the only one touching the file.  So if a user were to attempt to set the hostname later, without using cloud-init, cloud-init will attempt to change it back on the first reboot.  Because of this we opted to disable hostname changes by cloud-init.

https://bugzilla.redhat.com/show_bug.cgi?id=1282927
https://bugzilla.redhat.com/show_bug.cgi?id=1278904
