### PR TITLE
Change systemd service KillMode to process

### DIFF
--- a/COPY/usr/lib/systemd/system/evmserverd.service
+++ b/COPY/usr/lib/systemd/system/evmserverd.service
@@ -7,6 +7,7 @@ ExecStart=/bin/sh -c "/bin/evmserver.sh start"
 ExecStop=/bin/sh -c "/bin/evmserver.sh stop"
 Type=forking
 Restart=on-failure
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We need the evmserverd process to exit while performing
an update.
To do this we run `systemctl stop evmserverd` which brings
down the main process in the tree managed by systemd.
When the main process exits, systemd sends a sigterm to all
other processes in the tree, killing the update process.

This change will tell systemd to not kill other processes in
the tree after the main one has exited.

See `man systemd.kill` for more info.

https://bugzilla.redhat.com/show_bug.cgi?id=1239035
