### PR TITLE
Change logrotate free space check script to read free space correctly

### DIFF
--- a/logrotate_free_space_check.sh
+++ b/logrotate_free_space_check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 file=$1
 logger_file=/var/www/miq/vmdb/log/appliance_console.log
-logvol_free_space=`df -lk $file | awk '{ print $3 }' | tail -n 1`
+logvol_free_space=`df -lk $file | awk '{ print $4 }' | tail -n 1`
 existing_log_size=`du -k $file | awk '{ print $1 }' | tail -n 1`
 size_needed=$(($existing_log_size+($existing_log_size/5)))
 echo "$(date) Checking for enough free space to rotate: $file" >> $logger_file


### PR DESCRIPTION
Previously we were reading space used as free space.

https://bugzilla.redhat.com/show_bug.cgi?id=1294991
