### PR TITLE
[auth] Adding support for SAML External Authentication

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/cfme-external-auth-saml.conf
+++ b/TEMPLATE/etc/httpd/conf.d/cfme-external-auth-saml.conf
@@ -1,0 +1,37 @@
+
+LoadModule auth_mellon_module modules/mod_auth_mellon.so
+
+<Location />
+  MellonEnable                  "info"
+
+  MellonIdPMetadataFile         "/etc/httpd/saml2/idp-metadata.xml"
+
+  MellonSPPrivateKeyFile        "/etc/httpd/saml2/miqsp-key.key"
+  MellonSPCertFile              "/etc/httpd/saml2/miqsp-cert.cert"
+  MellonSPMetadataFile          "/etc/httpd/saml2/miqsp-metadata.xml"
+
+  MellonVariable                "miq-cookie"
+  MellonSecureCookie            On
+  MellonCookiePath              "/"
+
+  MellonIdP                     "IDP"
+
+  MellonEndpointPath            "/saml2"
+
+  MellonUser                    username
+  MellonMergeEnvVars            On
+
+  MellonSetEnvNoPrefix          "REMOTE_USER"            username
+  MellonSetEnvNoPrefix          "REMOTE_USER_EMAIL"      email
+  MellonSetEnvNoPrefix          "REMOTE_USER_FIRSTNAME"  firstname
+  MellonSetEnvNoPrefix          "REMOTE_USER_LASTNAME"   lastname
+  MellonSetEnvNoPrefix          "REMOTE_USER_FULLNAME"   fullname
+  MellonSetEnvNoPrefix          "REMOTE_USER_GROUPS"     groups
+</Location>
+
+<Location /saml_login>
+  AuthType                      "Mellon"
+  MellonEnable                  "auth"
+  Require                       valid-user
+</Location>
+


### PR DESCRIPTION
[auth] Adding support for SAML External Authentication
- Adding a template which can be used for SAML to protect /saml_login
  
  _note: _This is in lieu of cfme-external-auth.conf
- Setup mod_auth_mellon configuration to allow us to have both appliance login as well as the external IdP login via the seperate /saml_login entrypoint and without moving the appliance itself away from /

Trello: https://trello.com/c/YIUK4qLT
