### PR TITLE
bower - use -F to force latest version on conflict

### DIFF
--- a/cfme-setup.sh
+++ b/cfme-setup.sh
@@ -10,7 +10,7 @@ popd
 pushd /opt/manageiq/manageiq-ui-self_service
   npm install gulp bower -g
   npm install
-  bower --allow-root install
+  bower -F --allow-root install
   gulp build
 popd
 


### PR DESCRIPTION
This _should_ prevent the recurring `Unable to find a suitable version for (whatever), please choose one` errors during build..

@jvlcek ^^
