### PR TITLE
Allow postgres system user to log in as root db user

### DIFF
--- a/TEMPLATE/var/opt/rh/rh-postgresql94/lib/pgsql/data/pg_ident.conf
+++ b/TEMPLATE/var/opt/rh/rh-postgresql94/lib/pgsql/data/pg_ident.conf
@@ -2,3 +2,4 @@
 # users can login as themselves
 usermap         /^(.*)$                 \1
 usermap         root                    postgres
+usermap         postgres                root


### PR DESCRIPTION
This will allow the pglogical process to authenticate to the local database using the credentials in database.yml

https://trello.com/c/bRx6yN0C
