### PR TITLE
Change alias for `appliance_console` to `ap`

### DIFF
--- a/LINK/etc/profile.d/evm.sh
+++ b/LINK/etc/profile.d/evm.sh
@@ -1,6 +1,6 @@
 [[ -s "/etc/default/evm" ]] && source "/etc/default/evm"
 
 # Aliases:
-alias ad='/usr/bin/appliance_console'
+alias ap='/usr/bin/appliance_console'
 alias vmdb='cd /var/www/miq/vmdb'
 alias appliance='[[ -n ${APPLIANCE_SOURCE_DIRECTORY} ]] && cd ${APPLIANCE_SOURCE_DIRECTORY}'


### PR DESCRIPTION
Re-Addresses Trello card:
https://trello.com/c/0exG9Pca/193-1-create-alias-for-appliance-console-command-on-appliance
