### PR TITLE
Add an hourly check for log file growth.

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -1,6 +1,7 @@
 /var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/opt/rh/rh-postgresql94/lib/pgsql/data/pg_log/*.log {
   daily
-  dateext
+  size 1G
+  dateext dateformat -%Y%m%d-%s
   missingok
   rotate 14
   notifempty

--- a/LINK/etc/cron.hourly/miq-logrotate-hourly.cron
+++ b/LINK/etc/cron.hourly/miq-logrotate-hourly.cron
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+/usr/sbin/logrotate /etc/logrotate.d/miq_logs.conf
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit 0
+


### PR DESCRIPTION
This allows log rotation to continue daily but adds an
hourly safety check for excessive log file growth, ensuring
the appliance can still run.

https://bugzilla.redhat.com/show_bug.cgi?id=1327228
