### PR TITLE
No longer source the nodejs010 enable script

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -19,5 +19,4 @@ export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
 [[ -s /etc/default/evm_ruby ]] && source /etc/default/evm_ruby
 [[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
-[[ -s /opt/rh/nodejs010/enable ]] && source /opt/rh/nodejs010/enable
 [[ -s /etc/default/evm_productization ]] && source /etc/default/evm_productization


### PR DESCRIPTION
nodejs010 (scl package) was removed in favor of the nodejs version from the EPEL repo.

This line can now be removed.
