### PR TITLE
Enable hot_standby in postgresql.conf

### DIFF
--- a/TEMPLATE/var/opt/rh/rh-postgresql94/lib/pgsql/data/postgresql.conf.erb
+++ b/TEMPLATE/var/opt/rh/rh-postgresql94/lib/pgsql/data/postgresql.conf.erb
@@ -219,7 +219,7 @@ max_wal_senders = 10		# MIQ Value (pglogical) max number of walsender processes
 
 # These settings are ignored on a master server
 
-#hot_standby = off			# "on" allows queries during recovery
+hot_standby = on			# "on" allows queries during recovery
 					# (change requires restart)
 #max_standby_archive_delay = 30s	# max delay before canceling queries
 					# when reading WAL from archive;


### PR DESCRIPTION
This setting is harmless on a server that is not a standby but will be needed when we start supporting standby databases
