### PR TITLE
Rotate logs daily even if they are smaller than 1G

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -1,6 +1,6 @@
 /var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_log/*.log {
   daily
-  size 1G
+  maxsize 1G
   dateext dateformat -%Y%m%d-%s
   missingok
   rotate 14


### PR DESCRIPTION
A prior change inadvertently introduced a condition were logs
would only be rotated if they we 1G+ in size.

This change allows log rotation to continue daily regardless of
log size and hourly if there is excessive log file growth.

https://bugzilla.redhat.com/show_bug.cgi?id=1356267
