### PR TITLE
Remove the hourly check of log growth with possible rotation.

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -1,7 +1,6 @@
 /var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_log/*.log {
   daily
-  size 1G
-  dateext dateformat -%Y%m%d-%s
+  dateext
   missingok
   rotate 14
   notifempty

--- a/LINK/etc/cron.hourly/miq-logrotate-hourly.cron
+++ b/LINK/etc/cron.hourly/miq-logrotate-hourly.cron
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-/usr/sbin/logrotate /etc/logrotate.d/miq_logs.conf
-EXITVALUE=$?
-if [ $EXITVALUE != 0 ]; then
-    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
-fi
-exit 0
-


### PR DESCRIPTION
This PR will revert a change that was made to help prevent the MiQ vmdb/log volume from
filling with large logs by rotating them hourly when they are growing excessively. This
solutions is suboptimal for support, who has requested a different approach.

The commit and BZ being reverted are:
  https://bugzilla.redhat.com/show_bug.cgi?id=1327228

  https://bugzilla.redhat.com/show_bug.cgi?id=1329412

  [Commit](https://github.com/ManageIQ/manageiq-appliance/commit/72266f759ba7f77e633ee89748a337360466c3d3)
