### PR TITLE
Add support for running repmgrd for automatic database failover

### DIFF
--- a/COPY/etc/systemd/system/rh-repmgr95.service.d/config_file.conf
+++ b/COPY/etc/systemd/system/rh-repmgr95.service.d/config_file.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=REPMGRDCONF=/etc/repmgr.conf

--- a/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
+++ b/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
@@ -195,6 +195,7 @@ checkpoint_completion_target = 0.9	# MIQ Value;
 #archive_command = ''		# command to use to archive a logfile segment
 #archive_timeout = 0		# force a logfile segment switch after this
 				# number of seconds; 0 disables
+wal_log_hints = on
 
 
 #------------------------------------------------------------------------------

--- a/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
+++ b/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
@@ -132,7 +132,7 @@ shared_buffers = 128MB			# MIQ Value SHARED CONFIGURATION
 
 #max_files_per_process = 1000		# min 25
 					# (change requires restart)
-shared_preload_libraries = 'pglogical'		# MIQ Value (change requires restart)
+shared_preload_libraries = 'pglogical,repmgr_funcs'		# MIQ Value (change requires restart)
 
 # - Cost-Based Vacuum Delay -
 


### PR DESCRIPTION
This PR adds pieces required for running `repmgrd` for automated database failover.
1. Add repmgr_funcs to postgres' `shared_preload_libraries` list.
   - This is required for repmgrd, but also ties us to having the repmgr rpm installed in order to start postgres using our postgresql.conf template
2. Turn `wal_log_hints` on
   - This enables additional information in the wal logs needed by the `pg_rewind` tool. This tool allows us to add a failed primary server back into an HA cluster as a standby without re-copying the entire contents of the database. (See https://www.postgresql.org/docs/9.5/static/app-pgrewind.html)
3. Add a "drop-in" systemd configuration file to change the path to the repmgrd config file
   - We are writing our own config in `/etc/repmgr.conf` instead of using the default location (which points to the example configuration for some reason).

@gtanzillo please review
