### PR TITLE
Minor revisions to manageiq-http.conf to allow http config

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-http.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-http.conf
@@ -18,4 +18,14 @@ RewriteRule ^.*$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
 #  Include conf.d/manageiq-redirects-ws
 #  Include conf.d/manageiq-redirects-websocket
 #  ProxyPreserveHost on
+#  <Location /assets/>
+#    Header unset ETag
+#    FileETag None
+#    ExpiresActive On
+#    ExpiresDefault "access plus 1 year"
+#  </Location>
+#  <Location /proxy_pages/>
+#    ErrorDocument 403 /error/noindex.html
+#    ErrorDocument 404 /error/noindex.html
+#  </Location>
 #</VirtualHost>


### PR DESCRIPTION
mirror DocumentRoot, /assets/, and /proxy_pages/ from manageiq-https-application.conf to manageiq-http.conf and comment out

https://bugzilla.redhat.com/show_bug.cgi?id=1363700
