### PR TITLE
Force locale to avoid failures due to erroneous locale configurations

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -20,3 +20,9 @@ export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
 [[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
 [[ -s /etc/default/evm_productization ]] && source /etc/default/evm_productization
+
+# Force locale
+export LANGUAGE=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LC_CTYPE=en_US.UTF-8
+


### PR DESCRIPTION
ssh will set the locale to match the source host, which if not correctly
configured can result in invalid locale setting.

This change will ensure the locales are valid.

https://bugzilla.redhat.com/show_bug.cgi?id=1352822
