### PR TITLE
Add the APPLIANCE_PG_MOUNT_POINT environment variable

### DIFF
--- a/LINK/etc/default/evm_postgres
+++ b/LINK/etc/default/evm_postgres
@@ -3,7 +3,8 @@
 #
 
 export APPLIANCE_PG_CTL=/opt/rh/rh-postgresql95/root/usr/bin/pg_ctl
-export APPLIANCE_PG_DATA=/var/opt/rh/rh-postgresql95/lib/pgsql/data
+export APPLIANCE_PG_MOUNT_POINT=/var/opt/rh/rh-postgresql95/lib/pgsql
+export APPLIANCE_PG_DATA=${APPLIANCE_PG_MOUNT_POINT}/data
 export APPLIANCE_PG_SERVICE=rh-postgresql95-postgresql
 export APPLIANCE_PG_SCL_NAME=rh-postgresql95
 export APPLIANCE_PG_PACKAGE_NAME=${APPLIANCE_PG_SCL_NAME}-postgresql-server


### PR DESCRIPTION
This allows our code to distinguish between the data directory and the mount point which were previously the same.

This PR goes with https://github.com/ManageIQ/manageiq-appliance-build/pull/165 which changes the mount point for the postgresql disk on the appliance.

@jrafanie please review
/cc @gtanzillo @Fryguy 
