### PR TITLE
Update appliance status command(apstatus) to use systemctl and cleanup output

### DIFF
--- a/LINK/etc/profile.d/evm.sh
+++ b/LINK/etc/profile.d/evm.sh
@@ -13,4 +13,6 @@ function tailmiq() #If no value is given with tailmiq it defaults to the evm.log
 alias tailpglog='tail -f $APPLIANCE_PG_DATA/pg_log/postgresql.log'
 
 # Appliance Status:
-alias apstatus='echo "EVM Status:";service evmserverd status;echo " ";echo "HTTP Status:";service httpd status'
+alias apstatus='echo;systemctl status evmserverd -n 0;echo; \
+systemctl status httpd.service -n 0;echo;systemctl status memcached -n 0; \
+echo -e "\nPostgreSQL service:"; /opt/rh/$APPLIANCE_PG_SCL_NAME/root/usr/bin/pg_isready'

--- a/LINK/etc/profile.d/evm.sh
+++ b/LINK/etc/profile.d/evm.sh
@@ -15,4 +15,4 @@ alias tailpglog='tail -f $APPLIANCE_PG_DATA/pg_log/postgresql.log'
 # Appliance Status:
 alias apstatus='echo;systemctl status evmserverd -n 0;echo; \
 systemctl status httpd.service -n 0;echo;systemctl status memcached -n 0; \
-echo -e "\nPostgreSQL service:"; /opt/rh/$APPLIANCE_PG_SCL_NAME/root/usr/bin/pg_isready'
+echo -e "\nPostgreSQL service:"; pg_isready'


### PR DESCRIPTION
Convert the "apstatus" alias to use systemctl and show the status of evmserverd, httpd, memcached, and the PostgreSQL database.  

Output is similar to the following(abridged): 

● evmserverd.service - EVM server daemon
   Loaded: loaded (/usr/lib/systemd/system/evmserverd.service; enabled; vendor preset: disabled)
   Active: active (running) since Mon 2016-10-17 15:31:31 EDT; 3min 24s ago
  Process: 788 ExecStart=/bin/sh -c /bin/evmserver.sh start (code=exited, status=0/SUCCESS)
 Main PID: 2720 (ruby)
   CGroup: /system.slice/evmserverd.service
           ├─2720 MIQ Server
           ├─2914 MIQ: MiqEmsMetricsProcessorWorker id: 1000000000513
           ├─2926 MIQ: MiqEventHandler id: 1000000000515, queue: ems
           ├─2931 MIQ: MiqGenericWorker id: 1000000000516, queue: generic
           └─3021 puma 3.3.0 (tcp://127.0.0.1:4000) [MIQ: Web Server Worker]

● httpd.service - The Apache HTTP Server
   Loaded: loaded (/usr/lib/systemd/system/httpd.service; disabled; vendor preset: disabled)
   Active: active (running) since Mon 2016-10-17 15:32:23 EDT; 2min 31s ago
     Docs: man:httpd(8)
           man:apachectl(8)
 Main PID: 3066 (httpd)
   Status: "Total requests: 0; Current requests/sec: 0; Current traffic:   0 B/sec"
   CGroup: /system.slice/httpd.service
           ├─3066 /usr/sbin/httpd -DFOREGROUND
           └─3068 /usr/sbin/httpd -DFOREGROUND

● memcached.service - Memcached
   Loaded: loaded (/usr/lib/systemd/system/memcached.service; enabled; vendor preset: disabled)
   Active: active (running) since Mon 2016-10-17 15:31:56 EDT; 2min 58s ago
 Main PID: 2887 (memcached)
   CGroup: /system.slice/memcached.service
           └─2887 /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1

PostgreSQL service:
/var/run/postgresql:5432 - accepting connections
