### PR TITLE
Improve the postgres upgrade script

### DIFF
--- a/LINK/usr/bin/miq_postgres_upgrade.sh
+++ b/LINK/usr/bin/miq_postgres_upgrade.sh
@@ -14,8 +14,6 @@ NEW_PGSQL_DIR="/var/opt/rh/${NEW_PG_NAME}/lib/pgsql"
 
 PG_LV_DEV="/dev/mapper/vg_data-lv_pg"
 
-set -e
-
 # sanity checks
 
 # run as root
@@ -71,6 +69,8 @@ then
   echo "Exiting."
   exit 1
 fi
+
+set -e
 
 # fix mount point
 # TODO this can be removed when the default mount point is pgsql, rather than the data directory

--- a/LINK/usr/bin/miq_postgres_upgrade.sh
+++ b/LINK/usr/bin/miq_postgres_upgrade.sh
@@ -112,7 +112,9 @@ rm -rf ${OLD_PGSQL_DIR}/data
 
 # move new data directory into place
 mv ${NEW_PGSQL_DIR}/data-new ${NEW_PGSQL_DIR}/data
-restorecon -R ${NEW_PGSQL_DIR}
+
+restorecon -R /var/opt/rh/${NEW_PG_NAME}
+restorecon -R /opt/rh/${NEW_PG_NAME}
 
 # unmount volume from old location
 umount ${OLD_PGSQL_DIR}


### PR DESCRIPTION
This PR moves the `set -e` to a more appropriate place which fixes an issue where the script does not print an error if one of the checks fails.

Also (more importantly) this fixes an issue where some of the executable files in the installed postgres rpm do not have the correct SELinux context.

This was causing the PostgreSQL server process to not have permissions to access `postgresql.conf` which was preventing the server from starting.

https://bugzilla.redhat.com/show_bug.cgi?id=1386298
