### PR TITLE
Make pg upgrade script work with replication

### DIFF
--- a/LINK/usr/bin/miq_postgres_upgrade.sh
+++ b/LINK/usr/bin/miq_postgres_upgrade.sh
@@ -99,6 +99,8 @@ mount -a
 # init the new cluster
 su - postgres -c "initdb -D ${NEW_PGSQL_DIR}/data-new"
 
+sed -i.bak -e "s/^#*shared_preload_libraries.*/shared_preload_libraries = 'pglogical'/" ${NEW_PGSQL_DIR}/data-new/postgresql.conf
+
 # upgrade
 su - postgres -c "source /opt/rh/${OLD_PG_NAME}/enable; /opt/rh/${NEW_PG_NAME}/root/usr/bin/pg_upgrade -b /opt/rh/${OLD_PG_NAME}/root/usr/bin -B /opt/rh/${NEW_PG_NAME}/root/usr/bin -d ${OLD_PGSQL_DIR}/data -D ${OLD_PGSQL_DIR}/data-new -k"
 


### PR DESCRIPTION
This PR fixes three related issues with the upgrade script and replication

1. It adds pglogical to the shared preload libraries before we try to upgrade
    - This was required for pg_upgrade tried to recreate the pglogical schema in the new database
2. It recreates replication slots after the upgrade
    - On remote regions, a replication slot is needed for logical replication to function properly, but is not persisted across the pg_upgrade
    - We have to do this manually
3. It creates a replication origin for each subscription on global databases
    - PostgreSQL 9.5 introduced replication origins which allow us to track progress from the global
    - Each subscription *needs* one to function
    - https://www.postgresql.org/docs/9.5/static/replication-origins.html

Together these edits allow us to successfully upgrade databases using pglogical replication.
https://bugzilla.redhat.com/show_bug.cgi?id=1391693

@gtanzillo @Fryguy please review