### PR TITLE
Define RAILS_ROOT for the console

### DIFF
--- a/LINK/usr/bin/appliance_console
+++ b/LINK/usr/bin/appliance_console
@@ -1,7 +1,10 @@
-#!/bin/bash
-# description: ManageIQ appliance console launcher
-#
+#!/usr/bin/env ruby
 
-[[ -s /etc/default/evm ]] && source /etc/default/evm
+require "bundler"
+Bundler.setup
 
-ruby /var/www/miq/vmdb/gems/pending/appliance_console.rb $@
+require "pathname"
+RAILS_ROOT = Pathname.new("/var/www/miq/vmdb")
+
+require "manageiq-gems-pending"
+require "appliance_console"

--- a/LINK/usr/bin/appliance_console_cli
+++ b/LINK/usr/bin/appliance_console_cli
@@ -1,16 +1,11 @@
 #!/usr/bin/env ruby
 
-require "pathname"
-
-# Handle development environment by setting up Gemfile and manageiq location
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../manageiq/Gemfile', __dir__)
-ROOT ||= File.dirname(ENV['BUNDLE_GEMFILE'])
-
 require 'bundler'
 Bundler.setup
 
-$LOAD_PATH.push("#{ROOT}/gems/pending")
+require "pathname"
+RAILS_ROOT = Pathname.new("/var/www/miq/vmdb")
 
+require "manageiq-gems-pending"
 require 'appliance_console/cli'
-
 ApplianceConsole::Cli.parse(ARGV)


### PR DESCRIPTION
We used to define it on the fly if it wasn't already defined, but now that gems-pending is it's own gem we can't rely on the path of the files to figure out where RAILS_ROOT should be.

This is causing many of the options to fail.
Defining the constant here will allow the console to work while we work on fixing the gems-pending code to do something better.

@Fryguy please review