### PR TITLE
The checkmodule input file name must match the selinux module name

### DIFF
--- a/LINK/usr/bin/miqselinux.sh
+++ b/LINK/usr/bin/miqselinux.sh
@@ -4,7 +4,7 @@
 # The appliance needs an selinux policy to access sssd via dbus
 if [ -z "`/sbin/semodule -l | grep '^init_dbus_sssd	'`" ]
 then
-  SMOD=/tmp/miq_init_dbus_sssd
+  SMOD=/tmp/init_dbus_sssd
   cat - >$SMOD.te <<!END!
 module init_dbus_sssd 1.0;
 


### PR DESCRIPTION
When creating the SELinux policy module the input file name must now match the
name of the policy module. This change simply ensure the names match.

https://bugzilla.redhat.com/show_bug.cgi?id=1394066