### PR TITLE
Env variable was unused due to a missing trailing underscore

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -9,7 +9,6 @@ export HOME=${HOME:-/root}
 export EXECJS_RUNTIME='Node'
 # workaround for virtual memory spike observed with RHEL6
 export MALLOC_ARENA_MAX=1
-export MALLOC_MMAP_THRESHOLD=131072
 # Location of certificates and provider keys
 export KEY_ROOT=/var/www/miq/vmdb/certs
 


### PR DESCRIPTION
It should have been MALLOC_MMAP_THRESHOLD_.

Since we haven't been using it, let's just delete it.

"The environment variables are as follows (note the trailing
       underscore at the end of the name of some variables)"
http://man7.org/linux/man-pages/man3/mallopt.3.html

"Note that there is a trailing underscore on these variable names"
https://www.ibm.com/developerworks/community/blogs/kevgrig/entry/linux_native_memory_fragmentation_and_process_size_growth?lang=en