### PR TITLE
Add http redirects for the ansible API

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -10,6 +10,7 @@ DocumentRoot /var/www/miq/vmdb/public
 Include conf.d/manageiq-redirects-ws
 Include conf.d/manageiq-redirects-ui
 Include conf.d/manageiq-redirects-websocket
+Include conf.d/manageiq-redirects-ansible
 ProxyPreserveHost on
 RequestHeader set X_FORWARDED_PROTO 'https'
 

--- a/COPY/etc/httpd/conf.d/manageiq-redirects-ansible
+++ b/COPY/etc/httpd/conf.d/manageiq-redirects-ansible
@@ -1,0 +1,7 @@
+# add a trailing slash to all requests to the ansible api
+RewriteCond %{REQUEST_URI} ^/ansibleapi
+RewriteCond %{REQUEST_URI} !(.*)/$
+RewriteRule ^(.*)$ $1/ [R,L]
+
+ProxyPass /ansibleapi/ http://localhost:54321/api/
+ProxyPassReverse /ansibleapi/ http://localhost:54321/api/


### PR DESCRIPTION
This allows us to proxy requests through apache to the ansible API

This also allows us more control around what traffic goes to the nginx server. For example we only proxy to the /api end point and don't expose any of the rest of the application.

https://www.pivotaltracker.com/story/show/135450659