### PR TITLE
Require the watchdog using the manageiq-gems-pending gem

### DIFF
--- a/LINK/usr/bin/evm_watchdog.rb
+++ b/LINK/usr/bin/evm_watchdog.rb
@@ -2,7 +2,8 @@
 # description: ManageIQ watchdog application loop
 #
 
-require '/var/www/miq/vmdb/gems/pending/util/system/evm_watchdog'
+require 'manageiq-gems-pending'
+require 'util/system/evm_watchdog'
 
 EvmWatchdog.kill_other_watchdogs # To prevent duplicates.
 sleep(600) # 600s = 10 minute startup delay.


### PR DESCRIPTION
This was broken when the vmdb/gems/pending directory got broken out into a gem.

https://bugzilla.redhat.com/show_bug.cgi?id=1427200