### PR TITLE
Use manageiq-gems-pending gem instead of require_relative

### DIFF
--- a/LINK/usr/bin/evm_failover_monitor.rb
+++ b/LINK/usr/bin/evm_failover_monitor.rb
@@ -1,6 +1,6 @@
 #!/bin/env ruby
 
-require_relative '/var/www/miq/vmdb/gems/pending/bundler_setup'
+require 'manageiq-gems-pending'
 require 'postgres_ha_admin/failover_monitor'
 
 monitor = PostgresHaAdmin::FailoverMonitor.new


### PR DESCRIPTION
The gems-pending code was moved into a gem, so we cannot use a path to require the bundler environment anymore.

Requiring the gem directly gives us the same effect.