### PR TITLE
We need the bundle setup before requiring manageiq-gems-pending

### DIFF
--- a/LINK/usr/bin/evm_failover_monitor.rb
+++ b/LINK/usr/bin/evm_failover_monitor.rb
@@ -1,5 +1,8 @@
 #!/bin/env ruby
 
+require 'bundler'
+Bundler.setup
+
 require 'manageiq-gems-pending'
 require 'postgres_ha_admin/failover_monitor'
 

--- a/LINK/usr/bin/evm_watchdog.rb
+++ b/LINK/usr/bin/evm_watchdog.rb
@@ -2,6 +2,9 @@
 # description: ManageIQ watchdog application loop
 #
 
+require 'bundler'
+Bundler.setup
+
 require 'manageiq-gems-pending'
 require 'util/system/evm_watchdog'
 


### PR DESCRIPTION
Finishes implementing the fixes started in #108 and #109 

/cc @fbladilo