### PR TITLE
Add NE to the ansible api rewrite rule

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-redirects-ansible
+++ b/COPY/etc/httpd/conf.d/manageiq-redirects-ansible
@@ -1,7 +1,7 @@
 # add a trailing slash to all requests to the ansible api
 RewriteCond %{REQUEST_URI} ^/ansibleapi
 RewriteCond %{REQUEST_URI} !(.*)/$
-RewriteRule ^(.*)$ $1/ [R,L]
+RewriteRule ^(.*)$ $1/ [R,NE,L]
 
 ProxyPass /ansibleapi/ http://localhost:54321/api/
 ProxyPassReverse /ansibleapi/ http://localhost:54321/api/


### PR DESCRIPTION
Because we are proxying requests we don't want to re-encode already
URI encoded values.

Before this change, queries to the API like this:
`api.activity_stream.all(timestamp__gt: '2000-01-01 12:12')`

ended up with URLs like this:
`/ansibleapi/v1/activity_stream?timestamp__gt=2000-01-01+12%3A12`

which were then redirected to a URL which re-encodes the `%` character:
`/ansibleapi/v1/activity_stream/?timestamp__gt=2000-01-01+12%253A12`

This resulted in an invalid date format when un-encoded: `2000-01-01 12%3A12`

ref:
https://github.com/ManageIQ/manageiq/issues/14279
https://github.com/ManageIQ/manageiq/pull/14296

/cc @durandom