### PR TITLE
[WIP] Add defaults for pg 95 to conf

### DIFF
--- a/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
+++ b/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
@@ -1,5 +1,5 @@
 # -----------------------------
-# PostgreSQL configuration file - MIQ Shared Appliance Configuration
+# PostgreSQL configuration file
 # -----------------------------
 #
 # This file consists of lines of the form:
@@ -27,7 +27,7 @@
 # Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
 #                MB = megabytes                     s   = seconds
 #                GB = gigabytes                     min = minutes
-#                                                   h   = hours
+#                TB = terabytes                     h   = hours
 #                                                   d   = days
 
 
@@ -46,7 +46,7 @@
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-#external_pid_file = '(none)'		# write an extra PID file
+#external_pid_file = ''			# write an extra PID file
 					# (change requires restart)
 
 
@@ -56,18 +56,17 @@
 
 # - Connection Settings -
 
-listen_addresses = '*'			# MIQ Value;
 #listen_addresses = 'localhost'		# what IP address(es) to listen on;
 					# comma-separated list of addresses;
-					# defaults to 'localhost', '*' = all
+					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
 #port = 5432				# (change requires restart)
-max_connections = 1000			# MIQ Value;
-#max_connections = 100			# (change requires restart) Note:  Increasing max_connections costs ~400 bytes of shared memory per connection slot, plus lock space (see max_locks_per_transaction).
+max_connections = 100			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
-#unix_socket_directory = ''		# (change requires restart)
-unix_socket_group = 'postgres'			# (change requires restart)
-unix_socket_permissions = 0770		# begin with 0 to use octal notation
+#unix_socket_directories = '/var/run/postgresql, /tmp'	# comma-separated list of directories
+					# (change requires restart)
+#unix_socket_group = ''			# (change requires restart)
+#unix_socket_permissions = 0777		# begin with 0 to use octal notation
 					# (change requires restart)
 #bonjour = off				# advertise server via Bonjour
 					# (change requires restart)
@@ -77,32 +76,30 @@ unix_socket_permissions = 0770		# begin with 0 to use octal notation
 # - Security and Authentication -
 
 #authentication_timeout = 1min		# 1s-600s
-ssl = <%= ssl ? "on " : "off" %>                                                   # (change requires restart)
-ssl_cert_file = '/var/www/miq/vmdb/certs/postgres.crt'      # (change requires restart)
-ssl_key_file  = '/var/www/miq/vmdb/certs/postgres.key'      # (change requires restart)
-ssl_ca_file   = '/var/www/miq/vmdb/certs/root.crt'          # (change requires restart)
-#ssl_crl_file = '/var/www/miq/vmdb/certs/crl.crt'           # (change requires restart)
-#ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
+#ssl = off				# (change requires restart)
+#ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
 					# (change requires restart)
-#ssl_renegotiation_limit = 512MB	# amount of data between renegotiations
+#ssl_prefer_server_ciphers = on		# (change requires restart)
+#ssl_ecdh_curve = 'prime256v1'		# (change requires restart)
+#ssl_cert_file = 'server.crt'		# (change requires restart)
+#ssl_key_file = 'server.key'		# (change requires restart)
+#ssl_ca_file = ''			# (change requires restart)
+#ssl_crl_file = ''			# (change requires restart)
 #password_encryption = on
 #db_user_namespace = off
+#row_security = on
 
-# Kerberos and GSSAPI
+# GSSAPI using Kerberos
 #krb_server_keyfile = ''
-#krb_srvname = 'postgres'		# (Kerberos only)
 #krb_caseins_users = off
 
 # - TCP Keepalives -
 # see "man 7 tcp" for details
 
-tcp_keepalives_idle = 3			# MIQ Value;
 #tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
 					# 0 selects the system default
-tcp_keepalives_interval = 75		# MIQ Value;
 #tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
 					# 0 selects the system default
-tcp_keepalives_count = 9		# MIQ Value;
 #tcp_keepalives_count = 0		# TCP_KEEPCNT;
 					# 0 selects the system default
 
@@ -113,30 +110,41 @@ tcp_keepalives_count = 9		# MIQ Value;
 
 # - Memory -
 
-shared_buffers = 128MB			# MIQ Value SHARED CONFIGURATION
-#shared_buffers = 1GB			# MIQ Value DEDICATED CONFIGURATION
-#shared_buffers = 32MB			# min 128kB
+shared_buffers = 128MB			# min 128kB
+					# (change requires restart)
+#huge_pages = try			# on, off, or try
 					# (change requires restart)
 #temp_buffers = 8MB			# min 800kB
 #max_prepared_transactions = 0		# zero disables the feature
 					# (change requires restart)
-# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
-# per transaction slot, plus lock space (see max_locks_per_transaction).
-# It is not advisable to set max_prepared_transactions nonzero unless you
-# actively intend to use prepared transactions.
-#work_mem = 1MB				# min 64kB
-#maintenance_work_mem = 16MB		# min 1MB
+# Caution: it is not advisable to set max_prepared_transactions nonzero unless
+# you actively intend to use prepared transactions.
+#work_mem = 4MB				# min 64kB
+#maintenance_work_mem = 64MB		# min 1MB
+#autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #max_stack_depth = 2MB			# min 100kB
+dynamic_shared_memory_type = posix	# the default is the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# use none to disable dynamic shared memory
+
+# - Disk -
+
+#temp_file_limit = -1			# limits per-session temp file space
+					# in kB, or -1 for no limit
 
 # - Kernel Resource Usage -
 
 #max_files_per_process = 1000		# min 25
 					# (change requires restart)
-shared_preload_libraries = 'pglogical,repmgr_funcs'		# MIQ Value (change requires restart)
+#shared_preload_libraries = ''		# (change requires restart)
 
 # - Cost-Based Vacuum Delay -
 
-#vacuum_cost_delay = 0ms		# 0-100 milliseconds
+#vacuum_cost_delay = 0			# 0-100 milliseconds
 #vacuum_cost_page_hit = 1		# 0-10000 credits
 #vacuum_cost_page_miss = 10		# 0-10000 credits
 #vacuum_cost_page_dirty = 20		# 0-10000 credits
@@ -150,7 +158,8 @@ shared_preload_libraries = 'pglogical,repmgr_funcs'		# MIQ Value (change require
 
 # - Asynchronous Behavior -
 
-#effective_io_concurrency = 1		# 1-1000. 0 disables prefetching
+#effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
+#max_worker_processes = 8
 
 
 #------------------------------------------------------------------------------
@@ -159,10 +168,11 @@ shared_preload_libraries = 'pglogical,repmgr_funcs'		# MIQ Value (change require
 
 # - Settings -
 
-wal_level = 'logical' # MIQ Value (pglogical)
+#wal_level = minimal			# minimal, archive, hot_standby, or logical
 					# (change requires restart)
 #fsync = on				# turns forced synchronization on or off
-#synchronous_commit = on		# synchronization level; on, off, or local
+#synchronous_commit = on		# synchronization level;
+					# off, local, remote_write, or on
 #wal_sync_method = fsync		# the default is the first option
 					# supported by the operating system:
 					#   open_datasync
@@ -171,7 +181,9 @@ wal_level = 'logical' # MIQ Value (pglogical)
 					#   fsync_writethrough
 					#   open_sync
 #full_page_writes = on			# recover from partial page writes
-wal_buffers = 16MB			# MIQ Value;
+#wal_compression = off			# enable compression of full-page writes
+#wal_log_hints = off			# also do full page writes of non-critical updates
+					# (change requires restart)
 #wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
 					# (change requires restart)
 #wal_writer_delay = 200ms		# 1-10000 milliseconds
@@ -181,46 +193,56 @@ wal_buffers = 16MB			# MIQ Value;
 
 # - Checkpoints -
 
+#checkpoint_timeout = 5min		# range 30s-1h
 #max_wal_size = 1GB
 #min_wal_size = 80MB
-#checkpoint_timeout = 5min		# range 30s-1h
-checkpoint_completion_target = 0.9	# MIQ Value;
 #checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_warning = 30s		# 0 disables
 
 # - Archiving -
 
-#archive_mode = off		# allows archiving to be done
+#archive_mode = off		# enables archiving; off, on, or always
 				# (change requires restart)
 #archive_command = ''		# command to use to archive a logfile segment
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
 #archive_timeout = 0		# force a logfile segment switch after this
 				# number of seconds; 0 disables
-wal_log_hints = on
 
 
 #------------------------------------------------------------------------------
 # REPLICATION
 #------------------------------------------------------------------------------
 
+# - Sending Server(s) -
+
+# Set these on the master and on any standby that will send replication data.
+
+#max_wal_senders = 0		# max number of walsender processes
+				# (change requires restart)
+#wal_keep_segments = 0		# in logfile segments, 16MB each; 0 disables
+#wal_sender_timeout = 60s	# in milliseconds; 0 disables
+
+#max_replication_slots = 0	# max number of replication slots
+				# (change requires restart)
+#track_commit_timestamp = off	# collect timestamp of transaction commit
+				# (change requires restart)
+
 # - Master Server -
 
-# These settings are ignored on a standby server
+# These settings are ignored on a standby server.
 
-max_wal_senders = 10		# MIQ Value (pglogical) max number of walsender processes
-				# (change requires restart)
-#wal_sender_delay = 1s		# walsender cycle time, 1-10000 milliseconds
-#wal_keep_segments = 0		# in logfile segments, 16MB each; 0 disables
-#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
-#replication_timeout = 60s	# in milliseconds; 0 disables
 #synchronous_standby_names = ''	# standby servers that provide sync rep
 				# comma-separated list of application_name
 				# from standby(s); '*' = all
+#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
 
 # - Standby Servers -
 
-# These settings are ignored on a master server
+# These settings are ignored on a master server.
 
-hot_standby = on			# "on" allows queries during recovery
+#hot_standby = off			# "on" allows queries during recovery
 					# (change requires restart)
 #max_standby_archive_delay = 30s	# max delay before canceling queries
 					# when reading WAL from archive;
@@ -232,6 +254,11 @@ hot_standby = on			# "on" allows queries during recovery
 					# 0 disables
 #hot_standby_feedback = off		# send info from standby to prevent
 					# query conflicts
+#wal_receiver_timeout = 60s		# time that receiver waits for
+					# communication from master
+					# in milliseconds; 0 disables
+#wal_retrieve_retry_interval = 5s	# time to wait before retrying to
+					# retrieve WAL after a failed attempt
 
 
 #------------------------------------------------------------------------------
@@ -244,6 +271,7 @@ hot_standby = on			# "on" allows queries during recovery
 #enable_hashagg = on
 #enable_hashjoin = on
 #enable_indexscan = on
+#enable_indexonlyscan = on
 #enable_material = on
 #enable_mergejoin = on
 #enable_nestloop = on
@@ -258,7 +286,7 @@ hot_standby = on			# "on" allows queries during recovery
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005		# same scale as above
 #cpu_operator_cost = 0.0025		# same scale as above
-#effective_cache_size = 128MB
+#effective_cache_size = 4GB
 
 # - Genetic Query Optimizer -
 
@@ -286,26 +314,25 @@ hot_standby = on			# "on" allows queries during recovery
 
 # - Where to Log -
 
-#log_destination = 'stderr'		# Valid values are combinations of
+log_destination = 'stderr'		# Valid values are combinations of
 					# stderr, csvlog, syslog, and eventlog,
 					# depending on platform.  csvlog
 					# requires logging_collector to be on.
 
 # This is used when logging to stderr:
-logging_collector = on                  # Enable capturing of stderr and csvlog
+logging_collector = on			# Enable capturing of stderr and csvlog
 					# into log files. Required to be on for
 					# csvlogs.
 					# (change requires restart)
 
 # These are only used if logging_collector is on:
-#log_directory = 'pg_log'		# directory where log files are written,
+log_directory = 'pg_log'		# directory where log files are written,
 					# can be absolute or relative to PGDATA
-#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'	# log file name pattern,
-log_filename = 'postgresql.log'         # MIQlog file name pattern
+log_filename = 'postgresql-%a.log'	# log file name pattern,
 					# can include strftime() escapes
 #log_file_mode = 0600			# creation mode for log files,
 					# begin with 0 to use octal notation
-#log_truncate_on_rotation = off		# If on, an existing log file with the
+log_truncate_on_rotation = on		# If on, an existing log file with the
 					# same name as the new log file will be
 					# truncated rather than appended to.
 					# But such truncation only occurs on
@@ -313,23 +340,18 @@ log_filename = 'postgresql.log'         # MIQlog file name pattern
 					# or size-driven rotation.  Default is
 					# off, meaning append to existing files
 					# in all cases.
-#log_rotation_age = 1d			# Automatic rotation of logfiles will
+log_rotation_age = 1d			# Automatic rotation of logfiles will
 					# happen after that time.  0 disables.
-log_rotation_age = 0			# rotated by miq-logrotate
-#log_rotation_size = 10MB		# Automatic rotation of logfiles will
+log_rotation_size = 0			# Automatic rotation of logfiles will
 					# happen after that much log output.
 					# 0 disables.
-log_rotation_size = 0                   # rotated by miq-logrotate
 
 # These are relevant when logging to syslog:
 #syslog_facility = 'LOCAL0'
 #syslog_ident = 'postgres'
 
-#silent_mode = off			# Run server silently.
-					# DO NOT USE without syslog or
-					# logging_collector
-					# (change requires restart)
-
+# This is only relevant when logging to eventlog (win32):
+#event_source = 'PostgreSQL'
 
 # - When to Log -
 
@@ -372,7 +394,6 @@ log_rotation_size = 0                   # rotated by miq-logrotate
 					#   fatal
 					#   panic (effectively off)
 
-log_min_duration_statement = 5000	# MIQ Value- ANY statement > 5 seconds
 #log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
 					# and their durations, > 0 logs only
 					# statements running at least this number
@@ -387,14 +408,11 @@ log_min_duration_statement = 5000	# MIQ Value- ANY statement > 5 seconds
 #debug_pretty_print = on
 #log_checkpoints = off
 #log_connections = off
-log_connections = on            # manageiq Feb 2013 identify user and address at session start
 #log_disconnections = off
-log_disconnections = on         # manageiq Feb 2013 identify user, address and session duration at session end
 #log_duration = off
 #log_error_verbosity = default		# terse, default, or verbose messages
 #log_hostname = off
-log_line_prefix = '%t:%r:%c:%u@%d:[%p]:'	# MIQ Value;
-#log_line_prefix = ''			# special values:
+log_line_prefix = '< %m >'			# special values:
 					#   %a = application name
 					#   %u = user name
 					#   %d = database name
@@ -414,13 +432,20 @@ log_line_prefix = '%t:%r:%c:%u@%d:[%p]:'	# MIQ Value;
 					#        processes
 					#   %% = '%'
 					# e.g. '<%u%%%d> '
-log_lock_waits = on			# MIQ Value - used to track possible deadlock issues
 #log_lock_waits = off			# log lock waits >= deadlock_timeout
 #log_statement = 'none'			# none, ddl, mod, all
+#log_replication_commands = off
 #log_temp_files = -1			# log temporary files equal or larger
 					# than the specified size in kilobytes;
 					# -1 disables, 0 logs all temp files
-#log_timezone = '(defaults to server environment setting)'
+log_timezone = 'US/Eastern'
+
+
+# - Process Title -
+
+#cluster_name = ''			# added to process titles if nonempty
+					# (change requires restart)
+#update_process_title = on
 
 
 #------------------------------------------------------------------------------
@@ -430,11 +455,10 @@ log_lock_waits = on			# MIQ Value - used to track possible deadlock issues
 # - Query/Index Statistics Collector -
 
 #track_activities = on
-track_counts = on			# MIQ Value;
 #track_counts = on
+#track_io_timing = off
 #track_functions = none			# none, pl, all
-#track_activity_query_size = 1024 	# (change requires restart)
-#update_process_title = on
+#track_activity_query_size = 1024	# (change requires restart)
 #stats_temp_directory = 'pg_stat_tmp'
 
 
@@ -450,28 +474,25 @@ track_counts = on			# MIQ Value;
 # AUTOVACUUM PARAMETERS
 #------------------------------------------------------------------------------
 
-autovacuum = on				# MIQ Value;
 #autovacuum = on			# Enable autovacuum subprocess?  'on'
 					# requires track_counts to also be on.
-log_autovacuum_min_duration = 0		# MIQ Value;
 #log_autovacuum_min_duration = -1	# -1 disables, 0 logs all actions and
 					# their durations, > 0 logs only
 					# actions running at least this number
 					# of milliseconds.
 #autovacuum_max_workers = 3		# max number of autovacuum subprocesses
 					# (change requires restart)
-autovacuum_naptime = 5min		# MIQ Value;
 #autovacuum_naptime = 1min		# time between autovacuum runs
-autovacuum_vacuum_threshold = 500	# MIQ Value;
 #autovacuum_vacuum_threshold = 50	# min number of row updates before
 					# vacuum
-autovacuum_analyze_threshold = 500	# MIQ Value;
 #autovacuum_analyze_threshold = 50	# min number of row updates before
 					# analyze
-autovacuum_vacuum_scale_factor = 0.05	# MIQ Value;
 #autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
 #autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
 #autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
+					# (change requires restart)
+#autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
+					# before forced vacuum
 					# (change requires restart)
 #autovacuum_vacuum_cost_delay = 20ms	# default vacuum cost delay for
 					# autovacuum, in milliseconds;
@@ -487,7 +508,7 @@ autovacuum_vacuum_scale_factor = 0.05	# MIQ Value;
 
 # - Statement Behavior -
 
-#search_path = '"$user",public'		# schema names
+#search_path = '"$user", public'	# schema names
 #default_tablespace = ''		# a tablespace name, '' uses the default
 #temp_tablespaces = ''			# a list of tablespace names, '' uses
 					# only default tablespace
@@ -497,22 +518,26 @@ autovacuum_vacuum_scale_factor = 0.05	# MIQ Value;
 #default_transaction_deferrable = off
 #session_replication_role = 'origin'
 #statement_timeout = 0			# in milliseconds, 0 is disabled
-#statement_timeout = 43200000			# MIQ statment timeout of 12 hours as a default
+#lock_timeout = 0			# in milliseconds, 0 is disabled
 #vacuum_freeze_min_age = 50000000
 #vacuum_freeze_table_age = 150000000
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_freeze_table_age = 150000000
 #bytea_output = 'hex'			# hex, escape
 #xmlbinary = 'base64'
 #xmloption = 'content'
+#gin_fuzzy_search_limit = 0
+#gin_pending_list_limit = 4MB
 
 # - Locale and Formatting -
 
 datestyle = 'iso, mdy'
 #intervalstyle = 'postgres'
-#timezone = '(defaults to server environment setting)'
+timezone = 'US/Eastern'
 #timezone_abbreviations = 'Default'     # Select the set of available time zone
 					# abbreviations.  Currently, there are
 					#   Default
-					#   Australia
+					#   Australia (historical usage)
 					#   India
 					# You can create your own file in
 					# share/timezonesets/.
@@ -534,21 +559,19 @@ default_text_search_config = 'pg_catalog.english'
 
 #dynamic_library_path = '$libdir'
 #local_preload_libraries = ''
+#session_preload_libraries = ''
 
 
 #------------------------------------------------------------------------------
 # LOCK MANAGEMENT
 #------------------------------------------------------------------------------
 
-deadlock_timeout = 5s			# MIQ Value - one second is too low, 5 seconds is more "interesting"
 #deadlock_timeout = 1s
 #max_locks_per_transaction = 64		# min 10
 					# (change requires restart)
-# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
-# max_locks_per_transaction * (max_connections + max_prepared_transactions)
-# lock table slots.
 #max_pred_locks_per_transaction = 64	# min 10
 					# (change requires restart)
+
 
 #------------------------------------------------------------------------------
 # VERSION/PLATFORM COMPATIBILITY
@@ -559,12 +582,11 @@ deadlock_timeout = 5s			# MIQ Value - one second is too low, 5 seconds is more "
 #array_nulls = on
 #backslash_quote = safe_encoding	# on, off, or safe_encoding
 #default_with_oids = off
-escape_string_warning = off		# MIQ Value no sure why this is enabled
 #escape_string_warning = on
 #lo_compat_privileges = off
+#operator_precedence_warning = off
 #quote_all_identifiers = off
 #sql_inheritance = on
-standard_conforming_strings = off	# MIQ Value not sure why this is enabled
 #standard_conforming_strings = on
 #synchronize_seqscans = on
 
@@ -577,15 +599,25 @@ standard_conforming_strings = off	# MIQ Value not sure why this is enabled
 # ERROR HANDLING
 #------------------------------------------------------------------------------
 
-#exit_on_error = off				# terminate session on any error?
-#restart_after_crash = on			# reinitialize after backend crash?
+#exit_on_error = off			# terminate session on any error?
+#restart_after_crash = on		# reinitialize after backend crash?
+
+
+#------------------------------------------------------------------------------
+# CONFIG FILE INCLUDES
+#------------------------------------------------------------------------------
+
+# These options allow settings to be loaded from files other than the
+# default postgresql.conf.
+
+#include_dir = 'conf.d'			# include files ending in '.conf' from
+					# directory 'conf.d'
+#include_if_exists = 'exists.conf'	# include file only if it exists
+#include = 'special.conf'		# include file
 
 
 #------------------------------------------------------------------------------
 # CUSTOMIZED OPTIONS
 #------------------------------------------------------------------------------
 
-#custom_variable_classes = ''		# list of custom variable class names
-max_worker_processes = 10  # MIQ Value (pglogical)
-max_replication_slots = 10 # MIQ Value (pglogical)
-wal_sender_timeout = 0     # MIQ Value (pglogical)
+# Add settings for extensions here

--- a/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
+++ b/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf.erb
@@ -60,14 +60,18 @@
 					# comma-separated list of addresses;
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
+listen_addresses = '*'
 #port = 5432				# (change requires restart)
-max_connections = 100			# (change requires restart)
+#max_connections = 100			# (change requires restart)
+max_connections = 1000
 #superuser_reserved_connections = 3	# (change requires restart)
 #unix_socket_directories = '/var/run/postgresql, /tmp'	# comma-separated list of directories
 					# (change requires restart)
 #unix_socket_group = ''			# (change requires restart)
+unix_socket_group = 'postgres'
 #unix_socket_permissions = 0777		# begin with 0 to use octal notation
 					# (change requires restart)
+unix_socket_permissions = 0770
 #bonjour = off				# advertise server via Bonjour
 					# (change requires restart)
 #bonjour_name = ''			# defaults to the computer name
@@ -77,13 +81,17 @@ max_connections = 100			# (change requires restart)
 
 #authentication_timeout = 1min		# 1s-600s
 #ssl = off				# (change requires restart)
+ssl = <%= ssl ? "on " : "off" %>
 #ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
 					# (change requires restart)
 #ssl_prefer_server_ciphers = on		# (change requires restart)
 #ssl_ecdh_curve = 'prime256v1'		# (change requires restart)
 #ssl_cert_file = 'server.crt'		# (change requires restart)
+ssl_cert_file = '/var/www/miq/vmdb/certs/postgres.crt'
 #ssl_key_file = 'server.key'		# (change requires restart)
+ssl_key_file = '/var/www/miq/vmdb/certs/postgres.key'
 #ssl_ca_file = ''			# (change requires restart)
+ssl_ca_file = '/var/www/miq/vmdb/certs/root.crt'
 #ssl_crl_file = ''			# (change requires restart)
 #password_encryption = on
 #db_user_namespace = off
@@ -98,10 +106,13 @@ max_connections = 100			# (change requires restart)
 
 #tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
 					# 0 selects the system default
+tcp_keepalives_idle = 3
 #tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
 					# 0 selects the system default
+tcp_keepalives_interval = 75
 #tcp_keepalives_count = 0		# TCP_KEEPCNT;
 					# 0 selects the system default
+tcp_keepalives_count = 9
 
 
 #------------------------------------------------------------------------------
@@ -141,6 +152,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 #max_files_per_process = 1000		# min 25
 					# (change requires restart)
 #shared_preload_libraries = ''		# (change requires restart)
+shared_preload_libraries = 'pglogical,repmgr_funcs'
 
 # - Cost-Based Vacuum Delay -
 
@@ -160,6 +172,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
 #max_worker_processes = 8
+max_worker_processes = 10
 
 
 #------------------------------------------------------------------------------
@@ -170,6 +183,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #wal_level = minimal			# minimal, archive, hot_standby, or logical
 					# (change requires restart)
+wal_level = logical
 #fsync = on				# turns forced synchronization on or off
 #synchronous_commit = on		# synchronization level;
 					# off, local, remote_write, or on
@@ -184,8 +198,10 @@ dynamic_shared_memory_type = posix	# the default is the first option
 #wal_compression = off			# enable compression of full-page writes
 #wal_log_hints = off			# also do full page writes of non-critical updates
 					# (change requires restart)
+wal_log_hints = on
 #wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
 					# (change requires restart)
+wal_buffers = 16MB
 #wal_writer_delay = 200ms		# 1-10000 milliseconds
 
 #commit_delay = 0			# range 0-100000, in microseconds
@@ -197,6 +213,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 #max_wal_size = 1GB
 #min_wal_size = 80MB
 #checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+checkpoint_completion_target = 0.9
 #checkpoint_warning = 30s		# 0 disables
 
 # - Archiving -
@@ -221,11 +238,14 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #max_wal_senders = 0		# max number of walsender processes
 				# (change requires restart)
+max_wal_senders = 10
 #wal_keep_segments = 0		# in logfile segments, 16MB each; 0 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
+wal_sender_timeout = 0
 
 #max_replication_slots = 0	# max number of replication slots
 				# (change requires restart)
+max_replication_slots = 10
 #track_commit_timestamp = off	# collect timestamp of transaction commit
 				# (change requires restart)
 
@@ -244,6 +264,7 @@ dynamic_shared_memory_type = posix	# the default is the first option
 
 #hot_standby = off			# "on" allows queries during recovery
 					# (change requires restart)
+hot_standby = on
 #max_standby_archive_delay = 30s	# max delay before canceling queries
 					# when reading WAL from archive;
 					# -1 allows indefinite delay
@@ -328,8 +349,9 @@ logging_collector = on			# Enable capturing of stderr and csvlog
 # These are only used if logging_collector is on:
 log_directory = 'pg_log'		# directory where log files are written,
 					# can be absolute or relative to PGDATA
-log_filename = 'postgresql-%a.log'	# log file name pattern,
+#log_filename = 'postgresql-%a.log'	# log file name pattern,
 					# can include strftime() escapes
+log_filename = 'postgresql.log'
 #log_file_mode = 0600			# creation mode for log files,
 					# begin with 0 to use octal notation
 log_truncate_on_rotation = on		# If on, an existing log file with the
@@ -340,9 +362,10 @@ log_truncate_on_rotation = on		# If on, an existing log file with the
 					# or size-driven rotation.  Default is
 					# off, meaning append to existing files
 					# in all cases.
-log_rotation_age = 1d			# Automatic rotation of logfiles will
+#log_rotation_age = 1d			# Automatic rotation of logfiles will
 					# happen after that time.  0 disables.
-log_rotation_size = 0			# Automatic rotation of logfiles will
+log_rotation_age = 0
+#log_rotation_size = 0			# Automatic rotation of logfiles will
 					# happen after that much log output.
 					# 0 disables.
 
@@ -398,6 +421,7 @@ log_rotation_size = 0			# Automatic rotation of logfiles will
 					# and their durations, > 0 logs only
 					# statements running at least this number
 					# of milliseconds
+log_min_duration_statement = 5000
 
 
 # - What to Log -
@@ -408,11 +432,13 @@ log_rotation_size = 0			# Automatic rotation of logfiles will
 #debug_pretty_print = on
 #log_checkpoints = off
 #log_connections = off
+log_connections = on
 #log_disconnections = off
+log_disconnections = on
 #log_duration = off
 #log_error_verbosity = default		# terse, default, or verbose messages
 #log_hostname = off
-log_line_prefix = '< %m >'			# special values:
+#log_line_prefix = '< %m >'			# special values:
 					#   %a = application name
 					#   %u = user name
 					#   %d = database name
@@ -431,8 +457,9 @@ log_line_prefix = '< %m >'			# special values:
 					#   %q = stop here in non-session
 					#        processes
 					#   %% = '%'
-					# e.g. '<%u%%%d> '
+log_line_prefix = '%t:%r:%c:%u@%d:[%p]:'
 #log_lock_waits = off			# log lock waits >= deadlock_timeout
+log_lock_waits = on
 #log_statement = 'none'			# none, ddl, mod, all
 #log_replication_commands = off
 #log_temp_files = -1			# log temporary files equal or larger
@@ -480,14 +507,19 @@ log_timezone = 'US/Eastern'
 					# their durations, > 0 logs only
 					# actions running at least this number
 					# of milliseconds.
+log_autovacuum_min_duration = 0
 #autovacuum_max_workers = 3		# max number of autovacuum subprocesses
 					# (change requires restart)
 #autovacuum_naptime = 1min		# time between autovacuum runs
+autovacuum_naptime = 5min
 #autovacuum_vacuum_threshold = 50	# min number of row updates before
 					# vacuum
+autovacuum_vacuum_threshold = 500
 #autovacuum_analyze_threshold = 50	# min number of row updates before
 					# analyze
+autovacuum_analyze_threshold = 500
 #autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
+autovacuum_vacuum_scale_factor = 0.05
 #autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
 #autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
 					# (change requires restart)
@@ -567,6 +599,7 @@ default_text_search_config = 'pg_catalog.english'
 #------------------------------------------------------------------------------
 
 #deadlock_timeout = 1s
+deadlock_timeout = 5s
 #max_locks_per_transaction = 64		# min 10
 					# (change requires restart)
 #max_pred_locks_per_transaction = 64	# min 10
@@ -583,11 +616,13 @@ default_text_search_config = 'pg_catalog.english'
 #backslash_quote = safe_encoding	# on, off, or safe_encoding
 #default_with_oids = off
 #escape_string_warning = on
+escape_string_warning = off
 #lo_compat_privileges = off
 #operator_precedence_warning = off
 #quote_all_identifiers = off
 #sql_inheritance = on
 #standard_conforming_strings = on
+standard_conforming_strings = off
 #synchronize_seqscans = on
 
 # - Other Platforms and Clients -


### PR DESCRIPTION
This PR alters our postgresql.conf so that is has the most up-to-date defaults for PostgreSQL 9.5

This also alters how we record changes to this file so that the default values are preserved for informational purposes.

Now, instead of commenting `MIQ Value` for the values we change, the default is still visible.

https://www.pivotaltracker.com/story/show/143075427