### PR TITLE
Generate new certificate when the default one is not present

### DIFF
--- a/initialize_appliance.sh
+++ b/initialize_appliance.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
+set -e -o pipefail
 
-[[ ! -f "/var/www/miq/vmdb/certs/v2_key" ]] && appliance_console_cli --key
+KEYPATH="/var/www/miq/vmdb/certs"
+
+[[ ! -f "$KEYPATH/v2_key" ]] && appliance_console_cli --key
+
+CERT="$KEYPATH/server.cer"
+KEY="$CERT.key"
+if [ ! -f "$CERT" -a ! -f "$KEY" ]; then
+  (umask 077 ; openssl req -x509 -newkey rsa -days 1095 -keyout $KEY -out $CERT -subj "/CN=server" -nodes -batch)
+fi


### PR DESCRIPTION
This allows us to remove default certificate.

https://access.redhat.com/security/cve/CVE-2016-4457

Disscussed in depth at https://bugzilla.redhat.com/show_bug.cgi?id=1340877