### PR TITLE
Add the tower log files to our rotation script

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -1,4 +1,4 @@
-/var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_log/*.log {
+/var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_log/*.log /var/log/tower/*.log {
   daily
   dateext
   missingok


### PR DESCRIPTION
They also print logs to /var/log/supervisor/ but the supervisord rpm provides log rotation for those.

https://bugzilla.redhat.com/show_bug.cgi?id=1445069