### PR TITLE
Removing the PATH= from evmserver.sh

### DIFF
--- a/LINK/usr/bin/evmserver.sh
+++ b/LINK/usr/bin/evmserver.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local:/usr/local/sbin:/usr/local/bin
 BASEDIR="/var/www/miq/vmdb"
 RETVAL=0
 cd $BASEDIR


### PR DESCRIPTION
This is not necessary and clobbers the default PATH environment variable on containers.

Additionally the default path on the appliance is `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin` which covers all the locations listed here except for `/usr/local` which contains no executable files.