### PR TITLE
Add the appliance gem dependencies

### DIFF
--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,0 +1,1 @@
+# Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application


### PR DESCRIPTION
This file will be copied into the manageiq application's bundler.d directory at build time to include these gems into the bundle on an appliance.

This will allow more granular dependency declaration.

/cc @chessbyte @bdunne 