### PR TITLE
Disable connection reuse for WebSocket connections in Apache

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-balancer-websocket.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-balancer-websocket.conf
@@ -1,12 +1,15 @@
+# Temporarily disable the connection reuse for WebSockets for httpd version < 2.4.25
+# https://bugzilla.redhat.com/show_bug.cgi?id=1404354
+
 <Proxy balancer://evmcluster_websocket/ lbmethod=bybusyness>
-BalancerMember ws://0.0.0.0:5000
-BalancerMember ws://0.0.0.0:5001
-BalancerMember ws://0.0.0.0:5002
-BalancerMember ws://0.0.0.0:5003
-BalancerMember ws://0.0.0.0:5004
-BalancerMember ws://0.0.0.0:5005
-BalancerMember ws://0.0.0.0:5006
-BalancerMember ws://0.0.0.0:5007
-BalancerMember ws://0.0.0.0:5008
-BalancerMember ws://0.0.0.0:5009
+BalancerMember ws://0.0.0.0:5000 disablereuse=on
+BalancerMember ws://0.0.0.0:5001 disablereuse=on
+BalancerMember ws://0.0.0.0:5002 disablereuse=on
+BalancerMember ws://0.0.0.0:5003 disablereuse=on
+BalancerMember ws://0.0.0.0:5004 disablereuse=on
+BalancerMember ws://0.0.0.0:5005 disablereuse=on
+BalancerMember ws://0.0.0.0:5006 disablereuse=on
+BalancerMember ws://0.0.0.0:5007 disablereuse=on
+BalancerMember ws://0.0.0.0:5008 disablereuse=on
+BalancerMember ws://0.0.0.0:5009 disablereuse=on
 </Proxy>


### PR DESCRIPTION
This is a temporary workaround for the issue described here:
https://bugzilla.redhat.com/show_bug.cgi?id=1404354

This can be reverted after httpd is updated to 2.4.25 or newer
@miq-bot add_label bug, fine/yes, euwe/yes

Replacement of: https://github.com/ManageIQ/manageiq-gems-pending/pull/217

cc @psav, @gtanzillo, @jrafanie, @carbonin 