### PR TITLE
Rename ws to api to not be confused with websockets

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-balancer-api.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-balancer-api.conf
@@ -1,4 +1,4 @@
-<Proxy balancer://evmcluster_ws/ lbmethod=bybusyness>
+<Proxy balancer://evmcluster_api/ lbmethod=bybusyness>
 BalancerMember http://0.0.0.0:4000
 BalancerMember http://0.0.0.0:4001
 BalancerMember http://0.0.0.0:4002

--- a/COPY/etc/httpd/conf.d/manageiq-http.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-http.conf
@@ -15,8 +15,8 @@ RewriteRule ^.*$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
 # Enable this section if using HTTP only
 #<VirtualHost *:80>
 #  DocumentRoot /var/www/miq/vmdb/public
+#  Include conf.d/manageiq-redirects-api
 #  Include conf.d/manageiq-redirects-ui
-#  Include conf.d/manageiq-redirects-ws
 #  Include conf.d/manageiq-redirects-websocket
 #  ProxyPreserveHost on
 #  <Location /assets/>

--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -8,7 +8,7 @@ DocumentRoot /var/www/miq/vmdb/public
 # The following redirects files must be included to
 # handle most specific to least specific URLs.
 Include conf.d/manageiq-redirects-cockpit
-Include conf.d/manageiq-redirects-ws
+Include conf.d/manageiq-redirects-api
 Include conf.d/manageiq-redirects-ui
 Include conf.d/manageiq-redirects-websocket
 Include conf.d/manageiq-redirects-ansible

--- a/COPY/etc/httpd/conf.d/manageiq-redirects-api
+++ b/COPY/etc/httpd/conf.d/manageiq-redirects-api
@@ -1,0 +1,2 @@
+ProxyPass /api balancer://evmcluster_api/api
+ProxyPassReverse /api balancer://evmcluster_api/api

--- a/COPY/etc/httpd/conf.d/manageiq-redirects-ws
+++ b/COPY/etc/httpd/conf.d/manageiq-redirects-ws
@@ -1,2 +1,0 @@
-ProxyPass /api balancer://evmcluster_ws/api
-ProxyPassReverse /api balancer://evmcluster_ws/api


### PR DESCRIPTION
I find it SUPER confusing that we have both ws and websockets, but ws really means API *except* when [it actually means websockets](https://github.com/ManageIQ/manageiq-appliance/blob/72dd87638f10854a5e07d2a796a72aa0e0c79904/COPY/etc/httpd/conf.d/manageiq-balancer-websocket.conf#L5-L14).