### PR TITLE
Enable redis in /etc/default/evm

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -20,6 +20,8 @@ export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
 [[ -s /etc/default/evm_productization ]] && source /etc/default/evm_productization
 
+[[ -s /opt/rh/rh-redis32/enable ]] && source /opt/rh/rh-redis32/enable
+
 # Force locale
 export LANGUAGE=en_US.UTF-8
 export LANG=en_US.UTF-8


### PR DESCRIPTION
This is needed because redis is coming from rhscl which requires us to source the enable script to properly set up paths.

Requires https://github.com/ManageIQ/manageiq-appliance-build/pull/226