### PR TITLE
Run pg_inspector servers hourly

### DIFF
--- a/LINK/etc/cron.hourly/pg-inpsector-server-hourly.cron
+++ b/LINK/etc/cron.hourly/pg-inpsector-server-hourly.cron
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pg_inspector_server

--- a/LINK/etc/cron.hourly/pg-inpsector-server-hourly.cron
+++ b/LINK/etc/cron.hourly/pg-inpsector-server-hourly.cron
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pg_inspector_server
+pg_inspector_server.sh

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -3,4 +3,5 @@
 
 export PGPASSWORD="${PGPASSWORD:-smartvm}"
 [[ -s /etc/default/evm ]] && source /etc/default/evm
+export PATH=$PATH:/usr/local/bin
 /var/www/miq/vmdb/tools/pg_inspector.rb servers

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -2,4 +2,5 @@
 # description: dump miq_server table to YAML file
 
 export PGPASSWORD="${PGPASSWORD:-smartvm}"
+[[-s /etc/default/evm]] && source /etc/default/evm
 /var/www/miq/vmdb/tools/pg_inspector.rb servers

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# description: dump miq_server table to YAML file
+
+export PGPASSWORD="${PGPASSWORD:-smartvm}"
+/var/www/miq/vmdb/tools/pg_inspector.rb servers

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -2,5 +2,5 @@
 # description: dump miq_server table to YAML file
 
 export PGPASSWORD="${PGPASSWORD:-smartvm}"
-[[-s /etc/default/evm]] && source /etc/default/evm
+[[ -s /etc/default/evm ]] && source /etc/default/evm
 /var/www/miq/vmdb/tools/pg_inspector.rb servers


### PR DESCRIPTION
Run pg_inspector servers hourly. Place it the same place as other cron tasks. Moved from https://github.com/ManageIQ/manageiq/pull/16207

\cc @jrafanie @yrudman @gtanzillo
@miq-bot add-label tools