### PR TITLE
Add trailing slash to cockpit machine urls

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-redirects-cockpit
+++ b/COPY/etc/httpd/conf.d/manageiq-redirects-cockpit
@@ -6,4 +6,5 @@ RequestHeader set X-Forwarded-Proto 'https' env=HTTPS
     ProxyPassMatch "ws://localhost:9002/cws/cockpi$1/socket"
 </LocationMatch>
 
+RewriteRule ^/cws/=([^/]+)$ /cws/=$1/ [L,R=302]
 ProxyPass /cws/ http://localhost:9002/cws/


### PR DESCRIPTION
Work around for cockpits login page not setting a content-type. This was fixed back in May, but hasn't made it to rhel yet.

This means that if the machine to connect to contains a . apache might guess the wrong mime type. We can avoid the issue by adding a trailing slash to the machine url if one is not present.