### PR TITLE
ExecStart requires an absolute executable path

### DIFF
--- a/COPY/usr/lib/systemd/system/evm-failover-monitor.service
+++ b/COPY/usr/lib/systemd/system/evm-failover-monitor.service
@@ -3,7 +3,7 @@ Description=PostgreSQL Failover Monitor for ManageIQ
 After=evmserverd.service
 
 [Service]
-ExecStart=source /etc/default/evm && bundle exec postgres_ha_admin
+ExecStart=/bin/sh -c /etc/default/evm && bundle exec postgres_ha_admin
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
This PR addresses the issue where the evm-failover-monitor service failed to start.

This was caused by an invalid ExecStart line in the /usr/lib/systemd/system/evm-failover-monitor.service file


**To Test:**
1.provision appliance
2.run appliance_console
3.select option 9 'Configure Application Database Failover Monitor'



https://bugzilla.redhat.com/show_bug.cgi?id=1508843