### PR TITLE
mute cron mail when no error

### DIFF
--- a/LINK/etc/cron.hourly/pg-inpsector-server-hourly.cron
+++ b/LINK/etc/cron.hourly/pg-inpsector-server-hourly.cron
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pg_inspector_server.sh
+pg_inspector_server.sh > /dev/null

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # description: dump miq_server table to YAML file
-
+exec 2>&1
 export PGPASSWORD="${PGPASSWORD:-smartvm}"
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 export PATH=$PATH:/usr/local/bin


### PR DESCRIPTION
Use the method in http://www.putorius.net/2015/03/stop-cron-daemon-from-sending-email-for.html to have cron mail only when error happens. Need to wait verify this works in several hours before remove WIP.

\cc @gtanzillo @carbonin 

@miq-bot add-label wip