### PR TITLE
Use a login shell for the failover monitor service

### DIFF
--- a/COPY/usr/lib/systemd/system/evm-failover-monitor.service
+++ b/COPY/usr/lib/systemd/system/evm-failover-monitor.service
@@ -3,7 +3,7 @@ Description=PostgreSQL Failover Monitor for ManageIQ
 After=evmserverd.service
 
 [Service]
-ExecStart=/bin/sh -c /etc/default/evm && bundle exec postgres_ha_admin
+ExecStart=/bin/sh -l -c "bundle exec postgres_ha_admin"
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
As is, the ExecStart command was not working properly.
The issue can be seen with the following trivial example which will not print anything.

```bash
sh -c THING=1 && echo "$THING"
```

Sourcing `/etc/default/evm` is done when using a login shell so we can avoid the issue of how to source the script properly in a one line command.

https://bugzilla.redhat.com/show_bug.cgi?id=1512985