### PR TITLE
pg_inspector_server cron job use credentials and host from database.yml

### DIFF
--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -5,4 +5,4 @@ export PGPASSWORD="${PGPASSWORD:-smartvm}"
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 export PATH=$PATH:/usr/local/bin
 
-bundle exec /var/www/miq/vmdb/tools/pg_inspector/inspect_pg_server.rb
+/var/www/miq/vmdb/tools/pg_inspector/inspect_pg_server.rb

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -4,4 +4,5 @@ exec 2>&1
 export PGPASSWORD="${PGPASSWORD:-smartvm}"
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 export PATH=$PATH:/usr/local/bin
-/var/www/miq/vmdb/tools/pg_inspector.rb servers
+
+bundle exec /var/www/miq/vmdb/tools/pg_inspector/inspect_pg_server.rb

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -5,4 +5,5 @@ export PGPASSWORD="${PGPASSWORD:-smartvm}"
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 export PATH=$PATH:/usr/local/bin
 
-/var/www/miq/vmdb/tools/pg_inspector/inspect_pg_server.rb
+cd /var/www/miq/vmdb
+tools/pg_inspector/inspect_pg_server.rb

--- a/LINK/usr/bin/pg_inspector_server.sh
+++ b/LINK/usr/bin/pg_inspector_server.sh
@@ -5,5 +5,4 @@ export PGPASSWORD="${PGPASSWORD:-smartvm}"
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 export PATH=$PATH:/usr/local/bin
 
-cd /var/www/miq/vmdb
-tools/pg_inspector/inspect_pg_server.rb
+/var/www/miq/vmdb/tools/pg_inspector/inspect_pg_server.rb


### PR DESCRIPTION
Currently, pg_inspector_server cron job is always dump for local database, which is bad for our debug purpose. This fix and should be merged after https://github.com/ManageIQ/manageiq/pull/16419/files is merged. I think this also need to be back ported. 

\cc @jrafanie @yrudman @gtanzillo 
@miq-bot add-label enhancement, tools