### PR TITLE
Add /usr/local/bin to the path if it is missing

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -25,3 +25,4 @@ export LANGUAGE=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
 
+[[ ":$PATH:" != *":/usr/local/bin:"* ]] && PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
This is added on the appliance images by default, but not on the cloud and vargant images.

To be safe we will just add it everywhere.