### PR TITLE
Use a better command to add /usr/local/bin to the path

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -25,4 +25,4 @@ export LANGUAGE=en_US.UTF-8
 export LANG=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
 
-[[ ":$PATH:" != *":/usr/local/bin:"* ]] && PATH="/usr/local/bin:${PATH}"
+[[ ":$PATH:" == *":/usr/local/bin:"* ]] || PATH="/usr/local/bin:${PATH}"


### PR DESCRIPTION
Previously when /usr/local/bin was already on the path the command
would return an error status because the initial command was not
successful. With the new command a success status will be returned
in both cases.

This was failing the container builds because `source /etc/default/evm`
was exiting with 1

This was introduced in https://github.com/ManageIQ/manageiq-appliance/pull/159