### PR TITLE
Increase applinace_console version in manageiq-appliance-dependencies.rb  to 1.1 

### DIFF
--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,3 +1,3 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
-gem "manageiq-appliance_console", "~>1.0.1", :require => false
+gem "manageiq-appliance_console", "~>1.1", :require => false
 gem "manageiq-postgres_ha_admin", "~>1.0.0", :require => false


### PR DESCRIPTION
Increase applinace_console version in manageiq-appliance-dependencies.rb  to 1.1 

\cc @bdunne 