### PR TITLE
Show full message on command line

### DIFF
--- a/LINK/usr/bin/miqtop.sh
+++ b/LINK/usr/bin/miqtop.sh
@@ -29,5 +29,5 @@ then
 fi
 
 echo "miqtop: start: date time is-> $(date) $(date +%z)" >> ${LOG_FILE}
-TERM=dumb COLUMNS=512 top -b -d 60 >> ${LOG_FILE} 2>&1 &
+TERM=dumb COLUMNS=512 top -c -b -d 60 >> ${LOG_FILE} 2>&1 &
 echo $! >> ${PID_FILE}


### PR DESCRIPTION
Noticed that Fine-4 had top_output with just the word `ruby` in it.
apparently different versions of `top` react to `setproctitle(1)` differently.

I am a little confused because I thought this file had the full tilte in it, but I am not able to find an appliance that currently displays top with the full command name.

Having a shortened name made it tricky for me to track down the processes that were bogging down a vm.
 
---

This change converts top's output from:

```text
18378 root      23   3 1193800 691584   1388 S   0.0  4.9   0:01.81 ruby
18386 root      23   3 1193800 691576   1376 S   0.0  4.9   0:01.87 ruby
18354 root      23   3 1194828 691568   1384 S   0.0  4.9   0:01.80 ruby
```

to:

```text
17967 root      30  10 1193800 694204   2000 S   0.0  4.9   0:08.93 MIQ: MiqGenericWorker id: 347708, queue: generic
17974 root      21   1 1192772 692332   1864 S   0.0  4.9   0:08.59 MIQ: MiqPriorityWorker id: 347709, queue: generic
17983 root      21   1 1192772 692200   1868 S   0.0  4.9   0:08.75 MIQ: MiqPriorityWorker id: 347710, queue: generic
```

/cc @nicklamuro @jrafanie 
  