### PR TITLE
Adding alias apcli for appliance_conosle_cli

### DIFF
--- a/LINK/etc/profile.d/evm.sh
+++ b/LINK/etc/profile.d/evm.sh
@@ -2,6 +2,7 @@
 
 # Aliases:
 alias ap='appliance_console'
+alias apcli='appliance_console_cli'
 alias vmdb='cd /var/www/miq/vmdb'
 alias appliance='[[ -n ${APPLIANCE_SOURCE_DIRECTORY} ]] && cd ${APPLIANCE_SOURCE_DIRECTORY}'
 


### PR DESCRIPTION
Hi

I found myself use appliance_console_cli very much since its feature enhancement issue at https://github.com/ManageIQ/manageiq-appliance_console/issues/7 .
I am proposing to add apcli alias in addition to existing ap.