### PR TITLE
Allow local replication connections

### DIFF
--- a/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_hba.conf
+++ b/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_hba.conf
@@ -1,4 +1,4 @@
-# TYPE  DATABASE USER  ADDRESS       METHOD
-local   all      all                 peer map=usermap
-hostssl all      all   all           md5
-host  replication  all  all  md5
+# TYPE  DATABASE    USER  ADDRESS METHOD
+local   all         all           peer map=usermap
+hostssl all         all   all     md5
+host    replication all   all     md5

--- a/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_hba.conf
+++ b/TEMPLATE/var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_hba.conf
@@ -1,4 +1,5 @@
 # TYPE  DATABASE    USER  ADDRESS METHOD
 local   all         all           peer map=usermap
+local   replication all           peer map=usermap
 hostssl all         all   all     md5
 host    replication all   all     md5


### PR DESCRIPTION
This will allow local database backups to succeed without
providing a host, username, and password

If a user attempted a backup of the local database
previously, it would fail with the following message:
`pg_basebackup: could not connect to server: FATAL:  no pg_hba.conf entry for replication connection from host "[local]", user "root", SSL off`

https://bugzilla.redhat.com/show_bug.cgi?id=1538584