### PR TITLE
httpd reload is not needed with copytruncate

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -9,7 +9,4 @@
   prerotate
     source /etc/default/evm; /bin/sh ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh $1
   endscript
-  lastaction
-    /sbin/service httpd reload > /dev/null 2>&1 || true
-  endscript
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1467007

As far as I can tell, when this was added originally in:
66b7a339cf1fc6deef9277bcf685a298bb79d4e4

the httpd reload was copied from the /etc/logrotate.d/httpd script
provided by the httpd package. The /etc/logrotate.d/httpd script
does this because the log files are rotated and httpd needs to reopen
the file descriptors for these logs. Interestingly, this is not required
if you use the 'copytruncate' option, which gracefully copies, compresses,
and truncates the logs without messing up any existing file descriptors.
Therefore, since we originally added this httpd reload in addition to
the 'copytruncate', we never needed the former.

See also:
https://bugzilla.redhat.com/show_bug.cgi?id=MANAGEIQ-13457