### PR TITLE
mod_ssl rpm loads the module so we don't have to

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https.conf
@@ -1,7 +1,5 @@
 ## ManageIQ SSL Global Context
 
-LoadModule ssl_module modules/mod_ssl.so
-
 Listen 443
 
 AddType application/x-x509-ca-cert .crt


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1572793

Loading the module a second time was leading to the following warning in
journal, /var/log/messages, etc.:

`AH01574: module ssl_module is already loaded, skipping`

This file loads mod_ssl.so:
```
$ cat /etc/httpd/conf.modules.d/00-ssl.conf
LoadModule ssl_module modules/mod_ssl.so
```
It's provided by mod_ssl rpm:
```
$ rpm -qf /etc/httpd/conf.modules.d/00-ssl.conf
mod_ssl-2.4.6-80.el7.x86_64
```

Since mod_ssl is a dependent rpm in our upstream kickstart[1] and downstream cfme-appliance[2], we should be able to just remove our loading of the module[3]

[1] https://github.com/ManageIQ/manageiq-appliance-build/blob/ddbdf493343eb3a6b3a16a1c17d2148bcc7b642a/kickstarts/partials/packages/includes.ks.erb#L32

[2] # rpm --test -e mod_ssl-2.4.6-80.el7.x86_64
error: Failed dependencies:
  mod_ssl is needed by (installed) cfme-appliance-5.9.2.0-1.el7cf.x86_64

[3] https://github.com/ManageIQ/manageiq-appliance/blob/0cfadef3468e64f1989e2b3e07bcf191a57071fa/COPY/etc/httpd/conf.d/manageiq-https.conf#L3