### PR TITLE
Add cache headers for webpack

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -28,6 +28,15 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 <Location /assets/>
   Header unset ETag
   FileETag None
+  Header merge Cache-Control public
+  ExpiresActive On
+  ExpiresDefault "access plus 1 year"
+</Location>
+
+<Location /packs/>
+  Header unset ETag
+  FileETag None
+  Header merge Cache-Control public
   ExpiresActive On
   ExpiresDefault "access plus 1 year"
 </Location>


### PR DESCRIPTION
### Overview

Pages are slow on a high latency connection

https://bugzilla.redhat.com/show_bug.cgi?id=1571223

### Synopsis

We currently use max-age for asset pipeline but ETags for webpack assets.
ETags cause requests over the wire to see if assets changed. Since assets have unique names, they will never change.

Chrome seems to mostly ignore cache headers, but firefox better follows
the contract.

### Before

We were using max-age for asset pipeline, but etags for webpack assets.
Firefox is hitting the server more frequently and downloading assets more often

### After

We are using max-age for both.
In addition, we are now setting Cache-control: public stating proxy servers can cache these assets

Fewer http requests and fewer assets going over the wire.

### Result

The results are confusing. It displays the same results in the `access_log`
And before and after display. Both firefox and chrome don't highlight number of http requests or the amount of data that goes over the wire vs what is read from cache.

The access log has the same results for both before and after:

```
192.168.118.1 - - [03/May/2018:15:41:12 -0400] "GET / HTTP/1.1" 304 -
```

The network tab for Firefox displays the same results for both before and after:

```
8 requests, 10.70mb page / 4.39kb transferred - finished 54ms (same comments)
```

Firefox's Network Monitor displays the key differences:

attribute         |unprimed    |before       |        after|change|
|---|---|---|---|---
Cached responses  |0           |6            |           10|67%|
Total requests    |12          |12           |           12|
Size:             |11,054.12 KB|2,760.28 KB  |      4.03 KB|99%
Transferred Size  |11,056.89 KB|2,761.75 KB  |      4.64 KB|99%
Time              |0.03 seconds|0.02 seconds |0.02 seconds |
Non blocking time |0.03 seconds|0.02 seconds |0.02 seconds |

We want to reduce data transferred, but also reduce the http checks that ask if the file has been modified.

It looks like we're making (12 total -10 cached) - (12 total - 6 cached) 4 fewer requests (67% improvement)

@miq-bot add_label bug performance

