### PR TITLE
[WIP] Make changes for repmgr version 4

### DIFF
--- a/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
+++ b/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
@@ -26,7 +26,7 @@ tcp_keepalives_interval = 75
 # RESOURCE USAGE (except WAL)
 #------------------------------------------------------------------------------
 
-shared_preload_libraries = 'pglogical,repmgr_funcs'
+shared_preload_libraries = 'pglogical,repmgr'
 max_worker_processes = 10
 
 #------------------------------------------------------------------------------

--- a/LINK/etc/sudoers.d/repmgr
+++ b/LINK/etc/sudoers.d/repmgr
@@ -1,0 +1,2 @@
+Defaults:postgres !requiretty
+postgres ALL = NOPASSWD: /usr/bin/systemctl stop rh-postgresql95-postgresql, /usr/bin/systemctl start rh-postgresql95-postgresql, /usr/bin/systemctl restart rh-postgresql95-postgresql, /usr/bin/systemctl reload rh-postgresql95-postgresql

--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,3 +1,3 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
-gem "manageiq-appliance_console", "~>2.0", ">=2.0.3", :require => false
-gem "manageiq-postgres_ha_admin", "~>1.0.0",          :require => false
+gem "manageiq-appliance_console", :git => "https://github.com/carbonin/manageiq-appliance_console", :branch => "repmgr4"
+gem "manageiq-postgres_ha_admin", :git => "https://github.com/carbonin/manageiq-postgres_ha_admin", :branch => "repmgr4"


### PR DESCRIPTION
Add a sudoers file to allow the postgresql user to use systemctl to manage the rh-postgresql95-postgresql service when run from repmgrd and change the name of the shared preload library for repmgrd.

https://www.pivotaltracker.com/story/show/141523501
https://www.pivotaltracker.com/story/show/135779733
https://bugzilla.redhat.com/show_bug.cgi?id=1418080