### PR TITLE
 Add the [default] header to .ansible.cfg

### DIFF
--- a/LINK/root/.ansible.cfg
+++ b/LINK/root/.ansible.cfg
@@ -1,1 +1,2 @@
+[default]
 stdout_callback = json


### PR DESCRIPTION
Without this `ansible-playbook` and the embedded ansible setup were
failing with:
```
[root@localhost ~]# ansible-playbook
Error reading config file (/root/.ansible.cfg): File contains no section headers.
file: /root/.ansible.cfg, line: 1
'stdout_callback = json\n'
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600048