### PR TITLE
Use the EvmDatabase method for evm-failover-monitor ExecStart

### DIFF
--- a/COPY/usr/lib/systemd/system/evm-failover-monitor.service
+++ b/COPY/usr/lib/systemd/system/evm-failover-monitor.service
@@ -3,7 +3,7 @@ Description=PostgreSQL Failover Monitor for ManageIQ
 After=evmserverd.service
 
 [Service]
-ExecStart=/bin/sh -l -c "bundle exec rails r \"EvmDatabase.run_failover_monitor\""
+ExecStart=/usr/bin/evm-failover-monitor
 Restart=on-failure
 
 [Install]

--- a/COPY/usr/lib/systemd/system/evm-failover-monitor.service
+++ b/COPY/usr/lib/systemd/system/evm-failover-monitor.service
@@ -3,7 +3,7 @@ Description=PostgreSQL Failover Monitor for ManageIQ
 After=evmserverd.service
 
 [Service]
-ExecStart=/bin/sh -l -c "bundle exec postgres_ha_admin"
+ExecStart=/bin/sh -l -c "bundle exec rails r \"EvmDatabase.run_failover_monitor\""
 Restart=on-failure
 
 [Install]

--- a/LINK/usr/bin/evm-failover-monitor
+++ b/LINK/usr/bin/evm-failover-monitor
@@ -1,0 +1,5 @@
+#!/bin/bash
+[[ -s "/etc/default/evm" ]] && source "/etc/default/evm"
+
+cd /var/www/miq/vmdb
+bundle exec rails r "EvmDatabase.run_failover_monitor"

--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,3 +1,2 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
 gem "manageiq-appliance_console", "~>3.2", :require => false
-gem "manageiq-postgres_ha_admin", "~>2.0", :require => false


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/17837

The bin file was removed from the gem in https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/10