### PR TITLE
Update ManageIQ::ApplianceConsole version dependency

### DIFF
--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,3 +1,3 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
-gem "manageiq-appliance_console", "~>3.1", :require => false
+gem "manageiq-appliance_console", "~>3.2", :require => false
 gem "manageiq-postgres_ha_admin", "~>2.0", :require => false


### PR DESCRIPTION
To bring in [ManageIQ/manageiq-appliance_console#62](https://github.com/ManageIQ/manageiq-appliance_console/pull/62)

cc @carbonin and @bdunne 