### PR TITLE
Change log time zone and format to match that of the core VMDBLogger

### DIFF
--- a/lib/evm_watchdog.rb
+++ b/lib/evm_watchdog.rb
@@ -78,7 +78,7 @@ module EvmWatchdog
 
   def self.log_info(message)
     File.open('/var/www/miq/vmdb/log/evm.log', 'a') do |f|
-      f.puts "[----] I, [#{Time.now.utc.iso8601(6)} ##{Process.pid}:#{Thread.current.object_id.to_s(16)}]  INFO -- : EvmWatchdog - #{message}"
+      f.puts "[----] I, [#{Time.now.strftime("%Y-%m-%dT%H:%M:%S.%6N".freeze)} ##{Process.pid}:#{Thread.current.object_id.to_s(16)}]  INFO -- : EvmWatchdog - #{message}"
     end
   end
 


### PR DESCRIPTION
The watchdog logger was logging messages with a UTC timestamp. However, the core `VMDBLogger` logs times in the local timezone. Since they both share the same evm.log file, this made troubleshooting more difficult having the timestamps in different timezones.

This PR addresses that by changing the watchdog log timestamp to local time as well as matching the time format to that of `VMDBLogger`

/cc @jrafanie 