### PR TITLE
Let API requests go through apache if they contain a CSRF token

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth.conf.erb
@@ -38,6 +38,7 @@ LoadModule lookup_identity_module modules/mod_lookup_identity.so
   SetEnvIf Authorization '^Basic +YWRtaW46' let_admin_in
   SetEnvIf X-Auth-Token  '^.+$'             let_api_token_in
   SetEnvIf X-MIQ-Token   '^.+$'             let_sys_token_in
+  SetEnvIf X-CSRF-Token  '^.+$'             let_csrf_token_in
 
   AuthType Basic
   AuthName "External Authentication (httpd) for API"
@@ -49,6 +50,7 @@ LoadModule lookup_identity_module modules/mod_lookup_identity.so
   Allow from env=let_admin_in
   Allow from env=let_api_token_in
   Allow from env=let_sys_token_in
+  Allow from env=let_csrf_token_in
   Satisfy Any
 
   LookupUserAttr mail        REMOTE_USER_EMAIL


### PR DESCRIPTION
With external authentication enabled, the apache forces any unauthorized API request to basic auth. With this change the requests from the UI will go through as they always contain the CSRF token. The authentication itself also requires a cookie which is set by the UI after a successful login there. These validations are done in https://github.com/ManageIQ/manageiq-api/pull/543

Thanks for the help of @jvlcek for setting up the testing environment.