### PR TITLE
Fix shebang for evm_watchdog

### DIFF
--- a/LINK/usr/bin/evm_watchdog.rb
+++ b/LINK/usr/bin/evm_watchdog.rb
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 # description: ManageIQ watchdog application loop
 #
 


### PR DESCRIPTION
`/bin` is a symlink for `/usr/bin`, so changing to the non-symlink location. Otherwise this causes a problem for downstream when put into RPM.