### PR TITLE
Add sssd.conf.erb to TEMPLATE directory for authselect support

### DIFF
--- a/TEMPLATE/etc/sssd/sssd.conf.erb
+++ b/TEMPLATE/etc/sssd/sssd.conf.erb
@@ -2,11 +2,11 @@
 
 autofs_provider = ldap
 ldap_schema = rfc2307bis
-ldap_search_base = <%= ldapbasedn %>
+ldap_search_base = <%= ldap_search_base %>
 id_provider = ldap
 auth_provider = ldap
 chpass_provider = ldap
-ldap_uri = <%= ldapserver %>
+ldap_uri = <%= ldap_uri %>
 ldap_id_use_start_tls = False
 cache_credentials = True
 ldap_tls_cacertdir = /etc/openldap/cacerts

--- a/TEMPLATE/etc/sssd/sssd.conf.erb
+++ b/TEMPLATE/etc/sssd/sssd.conf.erb
@@ -1,0 +1,35 @@
+[domain/default]
+
+autofs_provider = ldap
+ldap_schema = rfc2307bis
+ldap_search_base = <%= ldapbasedn %>
+id_provider = ldap
+auth_provider = ldap
+chpass_provider = ldap
+ldap_uri = <%= ldapserver %>
+ldap_id_use_start_tls = False
+cache_credentials = True
+ldap_tls_cacertdir = /etc/openldap/cacerts
+[sssd]
+services = nss, pam, autofs
+
+domains = default
+[nss]
+homedir_substring = /home
+
+[pam]
+
+[sudo]
+
+[autofs]
+
+[ssh]
+
+[pac]
+
+[ifp]
+
+[secrets]
+
+[session_recording]
+


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1707537

authconfig generates an sssd.conf template, authselect does not.

This PR adds file sssd.conf.erb under the TEMPLATE directory on appliances and will
be needed for RHEL8/CentOS8 based appliances that use authselect to establish
authentication setup.

This PR can be merged now as delivering the new file introduced, sssd.conf.erb, on ManageIQ
appliances built on OS releases earlier than RHEL8/CentOS8, where authconfig is available,
will have no ill effect.

Delivering this extra file will help allow OS release agnostic documentation and automated
tooling to be delivered.

### Links [Optional]
[manageiq/18751](https://github.com/ManageIQ/manageiq/pull/18751)
[manageiq_docs/1133](https://github.com/ManageIQ/manageiq_docs/pull/1133)


### Steps for Testing/QA
See the miqldap_to_sssd and documentation PR