### PR TITLE
Alter postgres conf for built in logical replication

### DIFF
--- a/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
+++ b/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
@@ -27,7 +27,7 @@ tcp_keepalives_interval = 75
 #------------------------------------------------------------------------------
 
 shared_preload_libraries = 'repmgr'
-max_worker_processes = 10
+max_worker_processes = 15
 
 #------------------------------------------------------------------------------
 # WRITE AHEAD LOG
@@ -45,6 +45,7 @@ checkpoint_completion_target = 0.9
 #------------------------------------------------------------------------------
 
 wal_sender_timeout = 0
+max_logical_replication_workers = 10
 
 #------------------------------------------------------------------------------
 # QUERY TUNING

--- a/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
+++ b/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
@@ -26,7 +26,7 @@ tcp_keepalives_interval = 75
 # RESOURCE USAGE (except WAL)
 #------------------------------------------------------------------------------
 
-shared_preload_libraries = 'pglogical,repmgr'
+shared_preload_libraries = 'repmgr'
 max_worker_processes = 10
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Remove the pglogical extension and tweak the logical replication parameters to support roughly 10 subscriptions by default.

Should be merged after https://github.com/ManageIQ/manageiq/pull/18686