### PR TITLE
Add the vmdb/content/ansible/roles directory to the role search path

### DIFF
--- a/LINK/root/.ansible.cfg
+++ b/LINK/root/.ansible.cfg
@@ -1,2 +1,3 @@
 [default]
 stdout_callback = json
+roles_path = /etc/ansible/roles:/var/www/miq/vmdb/content/ansible_consolidated/roles


### PR DESCRIPTION
This will be where we consolidate the plugin ansible content so these roles should be available to all playbooks that we run.