### PR TITLE
Do not forward /ui/service/console to the sui index.html

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-redirects-ui
+++ b/COPY/etc/httpd/conf.d/manageiq-redirects-ui
@@ -1,4 +1,4 @@
-RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]
+RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext|console)) /ui/service/index.html [L]
 RewriteRule ^/self_service(.*) /ui/service$1 [R]
 RewriteCond %{REQUEST_URI} !^/cws
 RewriteCond %{REQUEST_URI} !^/ws


### PR DESCRIPTION
As @himdel described [here](https://github.com/ManageIQ/manageiq-ui-service/pull/1565#issuecomment-515097468), we're forwarding SUI requests to its `index.html` which causes a 404 error for WebMKS remote consoles. The solution is to update the regex to skip the forwarding.

@miq-bot add_label bug, ivanchuk/yes, hammer/no

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732730