### PR TITLE
Correct the ansible config section name

### DIFF
--- a/LINK/root/.ansible.cfg
+++ b/LINK/root/.ansible.cfg
@@ -1,3 +1,3 @@
-[default]
+[defaults]
 stdout_callback = json
 roles_path = /etc/ansible/roles:/var/www/miq/vmdb/content/ansible_consolidated/roles


### PR DESCRIPTION
The ini file section name is "defaults" not "default"

This is why the roles path change was being ignored.
ref: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-roles-path

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1734902