### PR TITLE
Add support to automate external auth config for ldap

### DIFF
--- a/LINK/usr/bin/miq_config_sssd
+++ b/LINK/usr/bin/miq_config_sssd
@@ -1,0 +1,5 @@
+#!/bin/bash
+# description: ManageIQ miqldap_to_sssd launcher for a fresh configuration
+
+cd /var/www/miq/vmdb
+bundle exec ruby tools/miqldap_to_sssd.rb config $@

--- a/LINK/usr/bin/miq_config_sssd
+++ b/LINK/usr/bin/miq_config_sssd
@@ -1,5 +1,5 @@
 #!/bin/bash
-# description: ManageIQ miqldap_to_sssd launcher for a fresh configuration
+# description: ManageIQ miq_config_sssd_ldap launcher for a fresh configuration
 
 cd /var/www/miq/vmdb
-bundle exec ruby tools/miqldap_to_sssd.rb config $@
+bundle exec ruby tools/miq_config_sssd_ldap.rb config $@

--- a/LINK/usr/bin/miqldap_to_sssd
+++ b/LINK/usr/bin/miqldap_to_sssd
@@ -1,5 +1,5 @@
 #!/bin/bash
-# description: ManageIQ miqldap_to_sssd launcher
+# description: ManageIQ miqldap_to_sssd launcher for a conversion from MiqLdap
 
 cd /var/www/miq/vmdb
-bundle exec ruby tools/miqldap_to_sssd.rb "$@"
+bundle exec ruby tools/miqldap_to_sssd.rb convert $@

--- a/LINK/usr/bin/miqldap_to_sssd
+++ b/LINK/usr/bin/miqldap_to_sssd
@@ -1,5 +1,5 @@
 #!/bin/bash
-# description: ManageIQ miqldap_to_sssd launcher for a conversion from MiqLdap
+# description: ManageIQ miq_config_sssd_ldap launcher for a conversion from MiqLdap
 
 cd /var/www/miq/vmdb
-bundle exec ruby tools/miqldap_to_sssd.rb convert $@
+bundle exec ruby tools/miq_config_sssd_ldap.rb convert $@

--- a/LINK/usr/bin/normalize_userid_to_upn
+++ b/LINK/usr/bin/normalize_userid_to_upn
@@ -2,4 +2,4 @@
 # description: Launch miqldap_to_sssd to normalize userids to upn format
 
 cd /var/www/miq/vmdb
-bundle exec ruby tools/miqldap_to_sssd.rb "-n"
+bundle exec ruby tools/miqldap_to_sssd.rb convert -n

--- a/LINK/usr/bin/normalize_userid_to_upn
+++ b/LINK/usr/bin/normalize_userid_to_upn
@@ -1,5 +1,5 @@
 #!/bin/bash
-# description: Launch miqldap_to_sssd to normalize userids to upn format
+# description: Launch miq_config_sssd_ldap to normalize userids to upn format
 
 cd /var/www/miq/vmdb
-bundle exec ruby tools/miqldap_to_sssd.rb convert -n
+bundle exec ruby tools/miq_config_sssd_ldap.rb convert -n


### PR DESCRIPTION
This pull request goes with and relies on PR https://github.com/ManageIQ/manageiq/pull/19228

This PR introduced a new executable **_miq_config_sssd_ldap_** and provides needed updates to
the existing commands:  **_miqldap_to_sssd_** and **_normalize_userid_to_upn_**