### PR TITLE
Run top in command-line/program name mode

### DIFF
--- a/LINK/usr/bin/miqtop.sh
+++ b/LINK/usr/bin/miqtop.sh
@@ -29,5 +29,5 @@ then
 fi
 
 echo "miqtop: start: date time is-> $(date) $(date +%z)" >> ${LOG_FILE}
-TERM=dumb COLUMNS=512 top -b -d 60 >> ${LOG_FILE} 2>&1 &
+TERM=dumb COLUMNS=512 top -b -c -d 60 >> ${LOG_FILE} 2>&1 &
 echo $! >> ${PID_FILE}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1749494

In rhel/centos 7, procps-ng version 3.3.10, top would run in command-line mode without a .toprc.
With rhel/centos 8, 3.3.15, top does NOT run in command line mode by default so you must specify it.

Previously, we would see the proc title we set instead of "ruby".

See also: https://gitlab.com/procps-ng/procps/issues/6

cc @jdeubel