### PR TITLE
Updated dependencies to pick up latest manageiq-appliance_console

### DIFF
--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,2 +1,2 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
-gem "manageiq-appliance_console", "~>5.0", ">= 5.0.3", :require => false
+gem "manageiq-appliance_console", "~>5.0", ">= 5.1.0", :require => false


### PR DESCRIPTION
Updated dependencies to pick up latest (upcoming) manageiq-appliance_console 5.1.0 which would include the options for configuring the appliance for SAML Authentication.

https://bugzilla.redhat.com/show_bug.cgi?id=1767108