### PR TITLE
Remove SSLCipherSuite

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -20,7 +20,6 @@ LogLevel warn
 
 SSLEngine on
 SSLProtocol all -SSLv2 -SSLv3
-SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:!LOW
 SSLCertificateFile /var/www/miq/vmdb/certs/server.cer
 SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 


### PR DESCRIPTION
As recommended by Red Hat Security, this SSLCipherSuite was
cargo-culted, and it's better to rely upon the default RHEL/CentOS
SSLCipherSuite.  In RHEL8/CentOS8 (which the ManageIQ appliance is built
on), the defaults are better than what's specified here and will be kept
up to date.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1784940

---

@simaishi Please review.  *Technically* this should go in after we bump to CentOS 8, but I think it's ok to merge in sooner.