### PR TITLE
[HAMMER] Replace SSLCipherSuite

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -21,7 +21,7 @@ LogLevel warn
 
 SSLEngine on
 SSLProtocol all -SSLv2 -SSLv3
-SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:!LOW
+SSLCipherSuite DEFAULT:-MEDIUM
 SSLCertificateFile /var/www/miq/vmdb/certs/server.cer
 SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 


### PR DESCRIPTION
hammer backport of https://github.com/ManageIQ/manageiq-appliance/pull/269 (86aeae0)

As recommended by Red Hat Security, this SSLCipherSuite was
cargo-culted, and this one is a better fit.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1794537

@simaishi Please review.