### PR TITLE
manageiq-external-auth: do NOT require authentication for /api/product_info

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth.conf.erb
@@ -37,7 +37,7 @@ LoadModule auth_kerb_module modules/mod_auth_kerb.so
 </LocationMatch>
 
 
-<LocationMatch ^/api|^/vmdbws/wsdl|^/vmdbws/api>
+<LocationMatch ^/api(?!\/product_info$)|^/vmdbws/wsdl|^/vmdbws/api>
   SetEnvIf Authorization '^Basic +YWRtaW46' let_admin_in
   SetEnvIf X-Auth-Token  '^.+$'             let_api_token_in
   SetEnvIf X-MIQ-Token   '^.+$'             let_sys_token_in

--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth.conf.erb
@@ -37,7 +37,7 @@ LoadModule auth_kerb_module modules/mod_auth_kerb.so
 </LocationMatch>
 
 
-<LocationMatch ^/api(?!\/product_info$)|^/vmdbws/wsdl|^/vmdbws/api>
+<LocationMatch ^/api(?!\/(v[\d\.]+\/)?product_info$)>
   SetEnvIf Authorization '^Basic +YWRtaW46' let_admin_in
   SetEnvIf X-Auth-Token  '^.+$'             let_api_token_in
   SetEnvIf X-MIQ-Token   '^.+$'             let_sys_token_in


### PR DESCRIPTION
The API has 2 sets of requests which can go in unauthenticated:

    app/controllers/api/base_controller.rb
    25:    before_action :require_api_user_or_token, :except => [:options, :product_info]
    27:    before_action :validate_api_request, :except => [:product_info]
    28:    before_action :validate_api_action, :except => [:options, :product_info]

That's OPTIONS requests, and a GET for `/api/product_info`.

We don't need OPTIONS quite yet (except for CORS preflight, which is not supported for the API currently),

but the Service UI is relying on unauthenticated `/api/product_info` to retrieve the URLs for brand assets (like the login screen logo).

Without this, the SUI login screen shows a browser login popup (and no branding), when running with external authentication.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1790817

Cc @jvlcek , thanks for all the help! :)