### PR TITLE
Remove .bowerrc

### DIFF
--- a/LINK/root/.bowerrc
+++ b/LINK/root/.bowerrc
@@ -1,4 +1,0 @@
-{
-	"allow_root": true,
-	"analytics": false
-}


### PR DESCRIPTION
bower was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/4735