### PR TITLE
Source evm_production (for RPM based appliance)

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -12,13 +12,10 @@ export MALLOC_ARENA_MAX=1
 # Location of certificates and provider keys
 export KEY_ROOT=/var/www/miq/vmdb/certs
 
-export APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance
-export APPLIANCE_TEMPLATE_DIRECTORY=${APPLIANCE_SOURCE_DIRECTORY}/TEMPLATE
-
 [[ -s /etc/default/evm_ruby ]] && source /etc/default/evm_ruby
 [[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
-[[ -s /etc/default/evm_productization ]] && source /etc/default/evm_productization
+source /etc/default/evm_production
 
 # Force locale
 export LANGUAGE=en_US.UTF-8


### PR DESCRIPTION
evm_production will be created by RPM, to allow customized path for APPLIANCE_SOURCE_DIRECTORY and APPLIANCE_TEMPLATE_DIRECTORY

Depends on https://github.com/ManageIQ/manageiq-appliance-build/pull/415