### PR TITLE
OIDC - bump dependency of appliance_console to 5.5

### DIFF
--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,2 +1,2 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
-gem "manageiq-appliance_console", "~>5.4", :require => false
+gem "manageiq-appliance_console", "~>5.5", :require => false


### PR DESCRIPTION
Appliance Console got bumped to 5.5 because of https://github.com/ManageIQ/manageiq-appliance_console/pull/117