### PR TITLE
Support OpenID-Connect with the Self Service UI

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
@@ -18,10 +18,11 @@ OIDCOAuthIntrospectionEndpointAuth client_secret_basic
   Require   valid-user
 </Location>
 
-<LocationMatch ^/ui/service.*$>
+<Location /ui/service/oidc_login>
   AuthType  openid-connect
   Require   valid-user
-</LocationMatch>
+  Header    set Set-Cookie "miq_oidc_access_token=%{OIDC_access_token}e; Max-Age=10; Path=/ui/service"
+</Location>
 
 <LocationMatch ^/api(?!\/(v[\d\.]+\/)?product_info$)>
   SetEnvIf Authorization '^Basic +YWRtaW46'     let_admin_in

--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
@@ -18,6 +18,11 @@ OIDCOAuthIntrospectionEndpointAuth client_secret_basic
   Require   valid-user
 </Location>
 
+<LocationMatch ^/ui/service.*$>
+  AuthType  openid-connect
+  Require   valid-user
+</LocationMatch>
+
 <LocationMatch ^/api(?!\/(v[\d\.]+\/)?product_info$)>
   SetEnvIf Authorization '^Basic +YWRtaW46'     let_admin_in
   SetEnvIf X-Auth-Token  '^.+$'                 let_api_token_in


### PR DESCRIPTION
both / ui-classic and /ui/service self-service UI share the same Apache config and client configuration so essentially enabling SSO between the two and the IDC for the same set of users. Logging out of Classic essentially logs out the user from Service UI (from same browser that is).