### PR TITLE
Add a script to generate rpm manifest

### DIFF
--- a/LINK/usr/bin/generate_rpm_manifest.sh
+++ b/LINK/usr/bin/generate_rpm_manifest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+manifest_dir=$APPLIANCE_SOURCE_DIRECTORY/../manifest
+mkdir -p $manifest_dir
+
+pushd $manifest_dir
+  manifest=rpm_manifest_$(date +"%m%d%y").csv
+
+  # dnf command gives yum repo used to install rpm
+  dnf list --installed | tr -s " " | while read name_arch version license
+  do
+    if [[ "$name_arch" == "Installed" ]]; then continue; fi
+    IFS=. read name arch <<< $name_arch
+    echo -e "$name\t$version\t$license" >> dnf_list
+  done
+  sort -o dnf_list dnf_list
+
+  # rpm command gives rpm license info
+  rpm -qa --qf '%{name}\t%{version}-%{release}.%{arch}\t"%{license}"\n' |sort > rpm_list
+  sed -i '/^gpg-pubkey/d' rpm_list
+
+  echo "name,version,license,repo" > $manifest
+  join -j 1 -o 1.1,1.2,1.3,2.3 -t $'\t' -a 1 rpm_list dnf_list >> $manifest
+  sed -i 's/\t/,/g' $manifest
+  rm -f rpm_list dnf_list
+popd


### PR DESCRIPTION
Includes name, version, license and yum repo where rpm was installed from.

/opt/manageiq/manifest/rpm_manifest_\<date\>.csv
```
name,version,license,repo
GConf2,3.2.6-22.el8.x86_64,"LGPLv2+ and GPLv2+",@AppStream
NetworkManager,1.22.8-4.el8.x86_64,"GPLv2+ and LGPLv2+",@BaseOS
NetworkManager-libnm,1.22.8-4.el8.x86_64,"LGPLv2+",@BaseOS
...
```
A part of https://github.com/ManageIQ/manageiq-appliance-build/pull/429