### PR TITLE
Add OIDCCacheShmEntrySizeMax parameter

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
@@ -8,6 +8,7 @@ OIDCClientSecret                   <%= oidc_client_secret %>
 OIDCRedirectURI                    https://<%= miq_appliance %>/oidc_login/redirect_uri
 OIDCCryptoPassphrase               sp-cookie
 OIDCOAuthRemoteUserClaim           username
+OIDCCacheShmEntrySizeMax           65536
 OIDCOAuthClientID                  <%= oidc_client_id %>
 OIDCOAuthClientSecret              <%= oidc_client_secret %>
 OIDCOAuthIntrospectionEndpoint     <%= oidc_introspection_endpoint %>


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/20511

This PR helps to ensure OIDC Cache is not undersized for most installations by increasing OIDCCacheShmEntrySizeMax from the default of 16913 bytes to 65536.