### PR TITLE
Add shebang for an exectuable file

### DIFF
--- a/LINK/etc/profile.d/evm.sh
+++ b/LINK/etc/profile.d/evm.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 [[ -s "/etc/default/evm" ]] && source "/etc/default/evm"
 
 # Aliases:


### PR DESCRIPTION
@simaishi Please review.  I'm going through files that have the executable bit but aren't directly executable (in this case because of a missing shebang).  Alternatively, I could change this PR to remove the executable bit.