### PR TITLE
Add RPM repo manifest

### DIFF
--- a/LINK/usr/bin/generate_rpm_manifest.sh
+++ b/LINK/usr/bin/generate_rpm_manifest.sh
@@ -4,6 +4,10 @@ manifest_dir=$APPLIANCE_SOURCE_DIRECTORY/../manifest
 mkdir -p $manifest_dir
 
 pushd $manifest_dir
+  #
+  # Generate RPM manifest
+  #
+
   manifest=rpm_manifest_$(date +"%m%d%y").csv
 
   # dnf command gives yum repo used to install rpm
@@ -23,4 +27,24 @@ pushd $manifest_dir
   join -j 1 -o 1.1,1.2,1.3,2.3 -t $'\t' -a 1 rpm_list dnf_list >> $manifest
   sed -i 's/\t/,/g' $manifest
   rm -f rpm_list dnf_list
+
+  #
+  # Generate RPM repo manifest
+  #
+  repo_manifest=rpm_repo_manifest_$(date +"%m%d%y").csv
+
+  dnf repolist -v enabled | ruby -r csv -e "$(cat <<- EORUBY
+    CSV(STDOUT) do |csv|
+      csv << %w[id name filename baseurl mirrors metalink]
+      STDIN
+        .grep(/^Repo-/)
+        .map { |line| line.chomp.split(":", 2).map(&:strip) }
+        .slice_when { |_, (k, _)| k == "Repo-id" }
+        .map { |repo| repo.to_h.values_at(*%w[Repo-id Repo-name Repo-filename Repo-baseurl Repo-mirrors Repo-metalink]) }
+        .sort_by { |repo| repo.first.downcase }
+        .each { |repo| csv << repo }
+    end
+EORUBY
+  )" > $repo_manifest
+
 popd


### PR DESCRIPTION
@simaishi Please review.  Example output looks like below (pretty version here: https://gist.github.com/Fryguy/bbc8bbe53256cd0e8773c5183a82cbf4)

```csv
id,name,filename,baseurl,mirrors,metalink
ansible-runner,Ansible Runner for EL 8 - x86_64,/etc/yum.repos.d/ansible-runner.repo,https://releases.ansible.com/ansible-runner/rpm/epel-8-x86_64/,,
AppStream,CentOS-8 - AppStream,/etc/yum.repos.d/CentOS-AppStream.repo,http://centos.vwtonline.net/centos/8.2.2004/AppStream/x86_64/os/ (9 more),http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=stock,
BaseOS,CentOS-8 - Base,/etc/yum.repos.d/CentOS-Base.repo,http://mirrors.cmich.edu/centos/8.2.2004/BaseOS/x86_64/os/ (9 more),http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=stock,
epel,Extra Packages for Enterprise Linux 8 - x86_64,/etc/yum.repos.d/epel.repo,http://mirror.pit.teraswitch.com/fedora/epel/8/Everything/x86_64/ (99 more),,https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=x86_64&infra=stock&content=centos
epel-modular,Extra Packages for Enterprise Linux Modular 8 - x86_64,/etc/yum.repos.d/epel-modular.repo,https://mirror.shastacoe.net/epel/8/Modular/x86_64/ (117 more),,https://mirrors.fedoraproject.org/metalink?repo=epel-modular-8&arch=x86_64&infra=stock&content=centos
extras,CentOS-8 - Extras,/etc/yum.repos.d/CentOS-Extras.repo,http://mirror.ash.fastserv.com/centos/8.2.2004/extras/x86_64/os/ (9 more),http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=extras&infra=stock,
manageiq-10-jansa,ManageIQ 10 (Jansa) Release- x86_64,/etc/yum.repos.d/manageiq-10-jansa.repo,https://rpm.manageiq.org/release/10-jansa/el8/x86_64,,
manageiq-10-jansa-nightly,ManageIQ 10 (Jansa) Nightly- x86_64,/etc/yum.repos.d/manageiq-10-jansa.repo,https://rpm.manageiq.org/release/10-jansa-nightly/el8/x86_64,,
manageiq-10-jansa-noarch,ManageIQ 10 (Jansa) Release- noarch,/etc/yum.repos.d/manageiq-10-jansa.repo,https://rpm.manageiq.org/release/10-jansa/el8/noarch,,
ovirt-4.4,Latest oVirt 4.4 Release,/etc/yum.repos.d/ovirt-4.4.repo,https://resources.ovirt.org/pub/ovirt-4.4/rpm/el8/ (12 more),https://resources.ovirt.org/pub/yum-repo/mirrorlist-ovirt-4.4-el8,
ovirt-4.4-advanced-virtualization,Advanced Virtualization packages for x86_64,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,http://mirror.us.oneandone.net/linux/distributions/centos/8.2.2004/virt/x86_64/advanced-virtualization/ (9 more),http://mirrorlist.centos.org/?arch=x86_64&release=8&repo=virt-advanced-virtualization,
ovirt-4.4-centos-gluster7,CentOS-8 - Gluster 7,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,http://mirror.chpc.utah.edu/pub/centos/8.2.2004/storage/x86_64/gluster-7/ (9 more),http://mirrorlist.centos.org?arch=x86_64&release=8&repo=storage-gluster-7,
ovirt-4.4-centos-opstools,CentOS-8 - OpsTools - collectd,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,http://mirrors.gigenet.com/centos/8.2.2004/opstools/x86_64/collectd-5/ (9 more),http://mirrorlist.centos.org/?arch=x86_64&release=8&repo=opstools-collectd-5,
ovirt-4.4-centos-ovirt44,CentOS-8 - oVirt 4.4,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,http://mirror.centos.lax1.serverforge.org/8.2.2004/virt/x86_64/ovirt-44/ (9 more),http://mirrorlist.centos.org/?arch=x86_64&release=8&repo=virt-ovirt-44,
ovirt-4.4-copr:copr.fedorainfracloud.org:mdbarroso:ovsdbapp,Copr repo for ovsdbapp owned by mdbarroso,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,https://copr-be.cloud.fedoraproject.org/results/mdbarroso/ovsdbapp/epel-8-x86_64/,,
ovirt-4.4-copr:copr.fedorainfracloud.org:networkmanager:NetworkManager-1.22,Copr repo for NetworkManager-1.22 owned by networkmanager,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,https://copr-be.cloud.fedoraproject.org/results/networkmanager/NetworkManager-1.22/epel-8-x86_64/,,
ovirt-4.4-copr:copr.fedorainfracloud.org:nmstate:nmstate-0.2,Copr repo for nmstate-stable owned by nmstate,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,https://copr-be.cloud.fedoraproject.org/results/nmstate/nmstate-0.2/epel-8-x86_64/,,
ovirt-4.4-copr:copr.fedorainfracloud.org:sac:gluster-ansible,Copr repo for gluster-ansible owned by sac,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,https://copr-be.cloud.fedoraproject.org/results/sac/gluster-ansible/epel-8-x86_64/,,
ovirt-4.4-copr:copr.fedorainfracloud.org:sbonazzo:EL8_collection,Copr repo for EL8_collection owned by sbonazzo,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,https://copr-be.cloud.fedoraproject.org/results/sbonazzo/EL8_collection/epel-8-x86_64/,,
ovirt-4.4-epel,Extra Packages for Enterprise Linux 8 - x86_64,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,http://mirror.sfo12.us.leaseweb.net/epel/8/Everything/x86_64/ (99 more),,https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=x86_64&infra=stock&content=centos
ovirt-4.4-virtio-win-latest,virtio-win builds roughly matching what will be shipped in upcoming RHEL,/etc/yum.repos.d/ovirt-4.4-dependencies.repo,https://fedorapeople.org/groups/virt/virtio-win/repo/latest,,
ubi-8-appstream,Red Hat Universal Base Image 8 (RPMs) - AppStream,/etc/yum.repos.d/ubi.repo,https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os,,
ubi-8-baseos,Red Hat Universal Base Image 8 (RPMs) - BaseOS,/etc/yum.repos.d/ubi.repo,https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os,,
ubi-8-codeready-builder,Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder,/etc/yum.repos.d/ubi.repo,https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/os,,
```