### PR TITLE
remove bundler:true from travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ rvm:
 - 2.5.7
 - 2.6.5
 sudo: false
-cache:
-  bundler: true
+cache: bundler


### PR DESCRIPTION
I thought it was for specifying directories to cache, since we don't have any, do we need this? 