### PR TITLE
Remove evm_bundler

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -13,7 +13,6 @@ export MALLOC_ARENA_MAX=1
 export KEY_ROOT=/var/www/miq/vmdb/certs
 
 [[ -s /etc/default/evm_ruby ]] && source /etc/default/evm_ruby
-[[ -s /etc/default/evm_bundler ]] && source /etc/default/evm_bundler
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
 source /etc/default/evm_production
 

--- a/LINK/etc/default/evm_bundler
+++ b/LINK/etc/default/evm_bundler
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-export BUNDLE_WITHOUT=test:metric_fu:development
-export BUNDLE_JOBS=1
-export BUNDLE_GEMFILE=/var/www/miq/vmdb/Gemfile
-
-# This is an environment variable we set in one place in the event
-# we want to use --local, --deployment, etc.
-export BUNDLE_CLI_OPTIONS=""


### PR DESCRIPTION
If we need to set bundle options, that should be done in manageiq-rpm_build repo now.

But we just need BUNDLE_GEMFILE on appliance now, so just moving that to gemset enable script in manageiq-rpm_build repo.

Depends on https://github.com/ManageIQ/manageiq-rpm_build/pull/96