### PR TITLE
remove sudo false from travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ language: ruby
 rvm:
 - 2.5.7
 - 2.6.5
-sudo: false
 cache: bundler


### PR DESCRIPTION
remove sudo:false which is no longer necessary: 
`In the next phase of the migration, all builds will run on virtual-machine-based infrastructure – regardless of the configuration for sudo in the .travis.yml. If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.`

from https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration