### PR TITLE
Disable old SSL Protocols < TLSv1.2

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -19,7 +19,7 @@ TransferLog /var/www/miq/vmdb/log/apache/ssl_access.log
 LogLevel warn
 
 SSLEngine on
-SSLProtocol all -SSLv2 -SSLv3
+SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
 SSLCertificateFile /var/www/miq/vmdb/certs/server.cer
 SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-rpm_build/issues/105

https://blog.mozilla.org/security/2018/10/15/removing-old-versions-of-tls/