### PR TITLE
[WIP] Statically define systemd service and target files

### DIFF
--- a/COPY/usr/lib/systemd/system/amazon_agent_coordinator.target
+++ b/COPY/usr/lib/systemd/system/amazon_agent_coordinator.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/amazon_agent_coordinator@.service
+++ b/COPY/usr/lib/systemd/system/amazon_agent_coordinator@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=amazon_agent_coordinator.target
+[Install]
+WantedBy=amazon_agent_coordinator.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Amazon::AgentCoordinatorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-amazon_agent_coordinator.slice

--- a/COPY/usr/lib/systemd/system/amazon_cloud_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/amazon_cloud_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/amazon_cloud_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/amazon_cloud_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=amazon_cloud_manager_event_catcher.target
+[Install]
+WantedBy=amazon_cloud_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Amazon::CloudManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-amazon_cloud_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/amazon_cloud_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/amazon_cloud_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/amazon_cloud_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/amazon_cloud_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=amazon_cloud_manager_metrics_collector.target
+[Install]
+WantedBy=amazon_cloud_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Amazon::CloudManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-amazon_cloud_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/amazon_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/amazon_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/amazon_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/amazon_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=amazon_cloud_manager_refresh.target
+[Install]
+WantedBy=amazon_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Amazon::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-amazon_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/amazon_storage_manager_s3_refresh.target
+++ b/COPY/usr/lib/systemd/system/amazon_storage_manager_s3_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/amazon_storage_manager_s3_refresh@.service
+++ b/COPY/usr/lib/systemd/system/amazon_storage_manager_s3_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=amazon_storage_manager_s3_refresh.target
+[Install]
+WantedBy=amazon_storage_manager_s3_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-amazon_storage_manager_s3_refresh.slice

--- a/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=ansible_tower_automation_manager_event_catcher.target
+[Install]
+WantedBy=ansible_tower_automation_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-ansible_tower_automation_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/ansible_tower_automation_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=ansible_tower_automation_manager_refresh.target
+[Install]
+WantedBy=ansible_tower_automation_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-ansible_tower_automation_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/autosde_storage_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/autosde_storage_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/autosde_storage_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/autosde_storage_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=autosde_storage_manager_refresh.target
+[Install]
+WantedBy=autosde_storage_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Autosde::StorageManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-autosde_storage_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/azure_cloud_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/azure_cloud_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/azure_cloud_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/azure_cloud_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=azure_cloud_manager_event_catcher.target
+[Install]
+WantedBy=azure_cloud_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Azure::CloudManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-azure_cloud_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/azure_cloud_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/azure_cloud_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/azure_cloud_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/azure_cloud_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=azure_cloud_manager_metrics_collector.target
+[Install]
+WantedBy=azure_cloud_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Azure::CloudManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-azure_cloud_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/azure_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/azure_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/azure_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/azure_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=azure_cloud_manager_refresh.target
+[Install]
+WantedBy=azure_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Azure::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-azure_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=azure_stack_cloud_manager_event_catcher.target
+[Install]
+WantedBy=azure_stack_cloud_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::AzureStack::CloudManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-azure_stack_cloud_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/azure_stack_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=azure_stack_cloud_manager_refresh.target
+[Install]
+WantedBy=azure_stack_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::AzureStack::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-azure_stack_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/azure_stack_network_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/azure_stack_network_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/azure_stack_network_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/azure_stack_network_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=azure_stack_network_manager_refresh.target
+[Install]
+WantedBy=azure_stack_network_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::AzureStack::NetworkManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-azure_stack_network_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/cockpit_ws.target
+++ b/COPY/usr/lib/systemd/system/cockpit_ws.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/cockpit_ws@.service
+++ b/COPY/usr/lib/systemd/system/cockpit_ws@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=cockpit_ws.target
+[Install]
+WantedBy=cockpit_ws.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqCockpitWsWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-cockpit_ws.slice

--- a/COPY/usr/lib/systemd/system/ems_metrics_processor.target
+++ b/COPY/usr/lib/systemd/system/ems_metrics_processor.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/ems_metrics_processor@.service
+++ b/COPY/usr/lib/systemd/system/ems_metrics_processor@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=ems_metrics_processor.target
+[Install]
+WantedBy=ems_metrics_processor.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-ems_metrics_processor.slice

--- a/COPY/usr/lib/systemd/system/event_handler.target
+++ b/COPY/usr/lib/systemd/system/event_handler.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/event_handler@.service
+++ b/COPY/usr/lib/systemd/system/event_handler@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=event_handler.target
+[Install]
+WantedBy=event_handler.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqEventHandler --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-event_handler.slice

--- a/COPY/usr/lib/systemd/system/foreman_configuration_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/foreman_configuration_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/foreman_configuration_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/foreman_configuration_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=foreman_configuration_manager_refresh.target
+[Install]
+WantedBy=foreman_configuration_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-foreman_configuration_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/generic.target
+++ b/COPY/usr/lib/systemd/system/generic.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/generic@.service
+++ b/COPY/usr/lib/systemd/system/generic@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=generic.target
+[Install]
+WantedBy=generic.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-generic.slice

--- a/COPY/usr/lib/systemd/system/google_cloud_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/google_cloud_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/google_cloud_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/google_cloud_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=google_cloud_manager_event_catcher.target
+[Install]
+WantedBy=google_cloud_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Google::CloudManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-google_cloud_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/google_cloud_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/google_cloud_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/google_cloud_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/google_cloud_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=google_cloud_manager_metrics_collector.target
+[Install]
+WantedBy=google_cloud_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Google::CloudManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-google_cloud_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/google_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/google_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/google_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/google_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=google_cloud_manager_refresh.target
+[Install]
+WantedBy=google_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Google::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-google_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/google_network_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/google_network_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/google_network_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/google_network_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=google_network_manager_refresh.target
+[Install]
+WantedBy=google_network_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Google::NetworkManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-google_network_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/ibm_cloud_power_virtual_servers_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/ibm_cloud_power_virtual_servers_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/ibm_cloud_power_virtual_servers_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/ibm_cloud_power_virtual_servers_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=ibm_cloud_power_virtual_servers_cloud_manager_refresh.target
+[Install]
+WantedBy=ibm_cloud_power_virtual_servers_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-ibm_cloud_power_virtual_servers_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/ibm_cloud_vpc_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/ibm_cloud_vpc_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/ibm_cloud_vpc_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/ibm_cloud_vpc_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=ibm_cloud_vpc_cloud_manager_refresh.target
+[Install]
+WantedBy=ibm_cloud_vpc_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::IbmCloud::VPC::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-ibm_cloud_vpc_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/ibm_terraform_configuration_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/ibm_terraform_configuration_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/ibm_terraform_configuration_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/ibm_terraform_configuration_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=ibm_terraform_configuration_manager_refresh.target
+[Install]
+WantedBy=ibm_terraform_configuration_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::IbmTerraform::ConfigurationManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-ibm_terraform_configuration_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/kubernetes_container_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/kubernetes_container_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/kubernetes_container_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/kubernetes_container_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=kubernetes_container_manager_event_catcher.target
+[Install]
+WantedBy=kubernetes_container_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-kubernetes_container_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/kubernetes_container_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/kubernetes_container_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/kubernetes_container_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/kubernetes_container_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=kubernetes_container_manager_metrics_collector.target
+[Install]
+WantedBy=kubernetes_container_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-kubernetes_container_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/kubernetes_container_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/kubernetes_container_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/kubernetes_container_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/kubernetes_container_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=kubernetes_container_manager_refresh.target
+[Install]
+WantedBy=kubernetes_container_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-kubernetes_container_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/kubernetes_monitoring_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/kubernetes_monitoring_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/kubernetes_monitoring_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/kubernetes_monitoring_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=kubernetes_monitoring_manager_event_catcher.target
+[Install]
+WantedBy=kubernetes_monitoring_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-kubernetes_monitoring_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/kubevirt_infra_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/kubevirt_infra_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/kubevirt_infra_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/kubevirt_infra_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=kubevirt_infra_manager_refresh.target
+[Install]
+WantedBy=kubevirt_infra_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Kubevirt::InfraManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-kubevirt_infra_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=lenovo_physical_infra_manager_event_catcher.target
+[Install]
+WantedBy=lenovo_physical_infra_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-lenovo_physical_infra_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/lenovo_physical_infra_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=lenovo_physical_infra_manager_refresh.target
+[Install]
+WantedBy=lenovo_physical_infra_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-lenovo_physical_infra_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/microsoft_infra_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/microsoft_infra_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/microsoft_infra_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/microsoft_infra_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=microsoft_infra_manager_refresh.target
+[Install]
+WantedBy=microsoft_infra_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Microsoft::InfraManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-microsoft_infra_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/nsxt_network_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/nsxt_network_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/nsxt_network_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/nsxt_network_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=nsxt_network_manager_refresh.target
+[Install]
+WantedBy=nsxt_network_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Nsxt::NetworkManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-nsxt_network_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/nuage_network_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/nuage_network_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/nuage_network_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/nuage_network_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=nuage_network_manager_event_catcher.target
+[Install]
+WantedBy=nuage_network_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Nuage::NetworkManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-nuage_network_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/nuage_network_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/nuage_network_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/nuage_network_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/nuage_network_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=nuage_network_manager_refresh.target
+[Install]
+WantedBy=nuage_network_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Nuage::NetworkManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-nuage_network_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/openshift_container_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/openshift_container_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openshift_container_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/openshift_container_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openshift_container_manager_event_catcher.target
+[Install]
+WantedBy=openshift_container_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openshift::ContainerManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openshift_container_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/openshift_container_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/openshift_container_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openshift_container_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/openshift_container_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openshift_container_manager_metrics_collector.target
+[Install]
+WantedBy=openshift_container_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openshift::ContainerManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openshift_container_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/openshift_container_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/openshift_container_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openshift_container_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/openshift_container_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openshift_container_manager_refresh.target
+[Install]
+WantedBy=openshift_container_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openshift_container_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/openshift_monitoring_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/openshift_monitoring_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openshift_monitoring_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/openshift_monitoring_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openshift_monitoring_manager_event_catcher.target
+[Install]
+WantedBy=openshift_monitoring_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openshift::MonitoringManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openshift_monitoring_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/openstack_cloud_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/openstack_cloud_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_cloud_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/openstack_cloud_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_cloud_manager_event_catcher.target
+[Install]
+WantedBy=openstack_cloud_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::CloudManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_cloud_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/openstack_cloud_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/openstack_cloud_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_cloud_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/openstack_cloud_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_cloud_manager_metrics_collector.target
+[Install]
+WantedBy=openstack_cloud_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_cloud_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/openstack_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/openstack_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/openstack_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_cloud_manager_refresh.target
+[Install]
+WantedBy=openstack_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/openstack_infra_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/openstack_infra_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_infra_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/openstack_infra_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_infra_manager_event_catcher.target
+[Install]
+WantedBy=openstack_infra_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::InfraManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_infra_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/openstack_infra_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/openstack_infra_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_infra_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/openstack_infra_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_infra_manager_metrics_collector.target
+[Install]
+WantedBy=openstack_infra_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::InfraManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_infra_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/openstack_infra_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/openstack_infra_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_infra_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/openstack_infra_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_infra_manager_refresh.target
+[Install]
+WantedBy=openstack_infra_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::InfraManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_infra_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/openstack_network_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/openstack_network_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_network_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/openstack_network_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_network_manager_event_catcher.target
+[Install]
+WantedBy=openstack_network_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::NetworkManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_network_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/openstack_storage_manager_cinder_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/openstack_storage_manager_cinder_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/openstack_storage_manager_cinder_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/openstack_storage_manager_cinder_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=openstack_storage_manager_cinder_manager_event_catcher.target
+[Install]
+WantedBy=openstack_storage_manager_cinder_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-openstack_storage_manager_cinder_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/priority.target
+++ b/COPY/usr/lib/systemd/system/priority.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/priority@.service
+++ b/COPY/usr/lib/systemd/system/priority@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=priority.target
+[Install]
+WantedBy=priority.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqPriorityWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-priority.slice

--- a/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=redfish_physical_infra_manager_event_catcher.target
+[Install]
+WantedBy=redfish_physical_infra_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Redfish::PhysicalInfraManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-redfish_physical_infra_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/redfish_physical_infra_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=redfish_physical_infra_manager_refresh.target
+[Install]
+WantedBy=redfish_physical_infra_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Redfish::PhysicalInfraManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-redfish_physical_infra_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/redhat_infra_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/redhat_infra_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/redhat_infra_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/redhat_infra_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=redhat_infra_manager_event_catcher.target
+[Install]
+WantedBy=redhat_infra_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Redhat::InfraManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-redhat_infra_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/redhat_infra_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/redhat_infra_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/redhat_infra_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/redhat_infra_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=redhat_infra_manager_metrics_collector.target
+[Install]
+WantedBy=redhat_infra_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Redhat::InfraManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-redhat_infra_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/redhat_infra_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/redhat_infra_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/redhat_infra_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/redhat_infra_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=redhat_infra_manager_refresh.target
+[Install]
+WantedBy=redhat_infra_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Redhat::InfraManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-redhat_infra_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/redhat_network_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/redhat_network_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/redhat_network_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/redhat_network_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=redhat_network_manager_event_catcher.target
+[Install]
+WantedBy=redhat_network_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Redhat::NetworkManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-redhat_network_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/redhat_network_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/redhat_network_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/redhat_network_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/redhat_network_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=redhat_network_manager_refresh.target
+[Install]
+WantedBy=redhat_network_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-redhat_network_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/remote_console.target
+++ b/COPY/usr/lib/systemd/system/remote_console.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/remote_console@.service
+++ b/COPY/usr/lib/systemd/system/remote_console@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=remote_console.target
+[Install]
+WantedBy=remote_console.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqRemoteConsoleWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-remote_console.slice

--- a/COPY/usr/lib/systemd/system/reporting.target
+++ b/COPY/usr/lib/systemd/system/reporting.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/reporting@.service
+++ b/COPY/usr/lib/systemd/system/reporting@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=reporting.target
+[Install]
+WantedBy=reporting.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqReportingWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-reporting.slice

--- a/COPY/usr/lib/systemd/system/schedule.target
+++ b/COPY/usr/lib/systemd/system/schedule.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/schedule@.service
+++ b/COPY/usr/lib/systemd/system/schedule@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=schedule.target
+[Install]
+WantedBy=schedule.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqScheduleWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-schedule.slice

--- a/COPY/usr/lib/systemd/system/smart_proxy.target
+++ b/COPY/usr/lib/systemd/system/smart_proxy.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/smart_proxy@.service
+++ b/COPY/usr/lib/systemd/system/smart_proxy@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=smart_proxy.target
+[Install]
+WantedBy=smart_proxy.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqSmartProxyWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-smart_proxy.slice

--- a/COPY/usr/lib/systemd/system/ui.target
+++ b/COPY/usr/lib/systemd/system/ui.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/ui@.service
+++ b/COPY/usr/lib/systemd/system/ui@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=ui.target
+[Install]
+WantedBy=ui.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqUiWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-ui.slice

--- a/COPY/usr/lib/systemd/system/vmware_cloud_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/vmware_cloud_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/vmware_cloud_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/vmware_cloud_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=vmware_cloud_manager_event_catcher.target
+[Install]
+WantedBy=vmware_cloud_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::CloudManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-vmware_cloud_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/vmware_cloud_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/vmware_cloud_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/vmware_cloud_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/vmware_cloud_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=vmware_cloud_manager_refresh.target
+[Install]
+WantedBy=vmware_cloud_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::CloudManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-vmware_cloud_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_event_catcher.target
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_event_catcher.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_event_catcher@.service
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_event_catcher@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=vmware_infra_manager_event_catcher.target
+[Install]
+WantedBy=vmware_infra_manager_event_catcher.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::EventCatcher --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-vmware_infra_manager_event_catcher.slice

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_metrics_collector.target
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_metrics_collector.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_metrics_collector@.service
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_metrics_collector@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=vmware_infra_manager_metrics_collector.target
+[Install]
+WantedBy=vmware_infra_manager_metrics_collector.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-vmware_infra_manager_metrics_collector.slice

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_operations.target
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_operations.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_operations@.service
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_operations@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=vmware_infra_manager_operations.target
+[Install]
+WantedBy=vmware_infra_manager_operations.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::OperationsWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-vmware_infra_manager_operations.slice

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_refresh.target
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_refresh.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/vmware_infra_manager_refresh@.service
+++ b/COPY/usr/lib/systemd/system/vmware_infra_manager_refresh@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=vmware_infra_manager_refresh.target
+[Install]
+WantedBy=vmware_infra_manager_refresh.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::RefreshWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-vmware_infra_manager_refresh.slice

--- a/COPY/usr/lib/systemd/system/web_service.target
+++ b/COPY/usr/lib/systemd/system/web_service.target
@@ -1,0 +1,2 @@
+[Unit]
+PartOf=miq.target

--- a/COPY/usr/lib/systemd/system/web_service@.service
+++ b/COPY/usr/lib/systemd/system/web_service@.service
@@ -1,0 +1,11 @@
+[Unit]
+PartOf=web_service.target
+[Install]
+WantedBy=web_service.target
+[Service]
+WorkingDirectory=/home/grare/adam/src/manageiq/manageiq
+Environment=BUNDLER_GROUPS=manageiq_default,ui_dependencies,graphql_api
+ExecStart=/bin/bash -lc 'exec ruby lib/workers/bin/run_single_worker.rb MiqWebServiceWorker --heartbeat --guid=%i'
+Restart=no
+Type=notify
+Slice=miq-web_service.slice


### PR DESCRIPTION
Currently these worker service and target files are written out dynamically by miq_server at startup.  This is an artifact of this having been an 'optional' feature in the past.

Typically service files are installed by the RPM that brings the service, not written by the service itself.