### PR TITLE
Remove watchdog update management

### DIFF
--- a/COPY/usr/lib/systemd/system/evm-watchdog.service
+++ b/COPY/usr/lib/systemd/system/evm-watchdog.service
@@ -3,7 +3,8 @@ Description=evm watchdog process
 After=evmserverd.service
 
 [Service]
-ExecStart=/bin/evm_watchdog
+EnvironmentFile=/etc/default/manageiq*.properties
+ExecStart=/usr/bin/ruby /usr/bin/evm_watchdog.rb
 Restart=on-failure
 
 [Install]

--- a/LINK/usr/bin/evm_watchdog.rb
+++ b/LINK/usr/bin/evm_watchdog.rb
@@ -11,6 +11,5 @@ EvmWatchdog.kill_other_watchdogs # To prevent duplicates.
 sleep(600) # 600s = 10 minute startup delay.
 loop do
   EvmWatchdog.check_evm
-  EvmWatchdog.check_for_update
   sleep(60) # 60s = 1 minute check frequency.
 end

--- a/lib/evm_watchdog.rb
+++ b/lib/evm_watchdog.rb
@@ -4,7 +4,6 @@ require 'fileutils'
 
 module EvmWatchdog
   PID_LOCATION = '/var/www/miq/vmdb/tmp/pids/evm.pid'.freeze
-  UPDATE_FILE  = '/var/www/miq/vmdb/tmp/miq_update'.freeze
 
   def self.check_evm
     pid_file = read_pid_file(PID_LOCATION)
@@ -37,13 +36,6 @@ module EvmWatchdog
         log_info("Detected a PID file: [#{pid_file}], but server state should be: [#{db_state}]...")
       end
     end
-  end
-
-  def self.check_for_update
-    return unless File.exist?(UPDATE_FILE)
-    packages = File.read(UPDATE_FILE).split
-    LinuxAdmin::Yum.update(*packages)
-    FileUtils.rm_f(UPDATE_FILE)
   end
 
   def self.read_pid_file(path_or_io)


### PR DESCRIPTION
part of: https://github.com/ManageIQ/manageiq/pull/21146

Remove update management from the watchdog process

The higher goal is to reduce the number of processes we run as the root user.
Since we no longer use redhat licensing, this is a good one to go.

### Before

check for an update file and run the appropriate tasks when it is found

### After

The update file will no longer be written, so this no longer makes sense.