### PR TITLE
remove unnecessary headers

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-http.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-http.conf
@@ -5,6 +5,8 @@ Timeout 120
 
 # HTTP Start-up error log
 ErrorLog /var/www/miq/vmdb/log/apache/miq_apache.log
+ServerSignature Off
+ServerTokens Prod
 
 RewriteEngine On
 


### PR DESCRIPTION
unnecessary headers which may help attackers in planning further attacks.

before:

```
Server: Apache/2.4.37 (centos) OpenSSL/1.1.1g mod_auth_gssapi/1.6.1
```

after:

```
Server: Apache
```

Apache wanted its vanity header, no way to completely turn it off