### PR TITLE
systemd don't write to evm.log

### DIFF
--- a/LINK/usr/bin/evmserver.sh
+++ b/LINK/usr/bin/evmserver.sh
@@ -40,13 +40,13 @@ status() {
 }
 
 update_start() {
-  bundle exec rake evm:update_start >> /var/www/miq/vmdb/log/evm.log 2>&1
+  bundle exec rake evm:update_start
   RETVAL=$?
   return $RETVAL
 }
 
 update_stop() {
-  bundle exec rake evm:update_stop >> /var/www/miq/vmdb/log/evm.log 2>&1
+  bundle exec rake evm:update_stop
   RETVAL=$?
   return $RETVAL
 }


### PR DESCRIPTION
for the `start` and `stop` tasks, we do not write to `evm.log` except
for the `update_stop` and `update_start` tasks.

This is making the systemd scripts more similar

High level - we have both root and non-root writing to the same files and this is the attempt to reduce that overlap