### PR TITLE
move appliance-init from build to appliance repo

### DIFF
--- a/COPY/usr/lib/systemd/system/manageiq-initialize.service
+++ b/COPY/usr/lib/systemd/system/manageiq-initialize.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Initialize Appliance Database
+ConditionPathExists=!/var/lib/pgsql/data/base
+After=evminit.service memcached.service
+Before=evmserverd.service
+Requires=memcached.service
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/manageiq-initialize.sh
+ExecStartPost=/usr/bin/systemctl disable manageiq-initialize
+[Install]
+WantedBy=multi-user.target

--- a/LINK/usr/bin/manageiq-initialize.sh
+++ b/LINK/usr/bin/manageiq-initialize.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+[[ -d /var/lib/pgsql/data/base ]] && exit 0
+[[ -s /etc/default/evm ]] && source /etc/default/evm
+echo "Initializing Appliance, please wait ..." > /dev/tty1
+appliance_console_cli --region 0 --internal --password smartvm --key
+appliance_console_cli --message-server-config --message-server-use-ipaddr --message-keystore-username="admin" --message-keystore-password="smartvm"


### PR DESCRIPTION
depends upon:

- [x] https://github.com/ManageIQ/manageiq-appliance-build/pull/480

This puts the appliance initialization under rpm control and under source control rather than dynamically created at kickstart time.

This makes the following changes:

- this file has changed names to manageiq-initialize to be more consistent with our file names
- since /bin is linked to /usr/bin, the target directory are in the same place
