### PR TITLE
no longer cache oidc_login pages

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
@@ -17,12 +17,20 @@ OIDCOAuthIntrospectionEndpointAuth client_secret_basic
 <Location /oidc_login>
   AuthType  openid-connect
   Require   valid-user
+  FileETag  None
+  Header    Set Cache-Control "max-age=0, no-store, no-cache, must-revalidate"
+  Header    Set Pragma "no-cache"
+  Header    Unset ETag
 </Location>
 
 <Location /ui/service/oidc_login>
   AuthType  openid-connect
   Require   valid-user
-  Header    set Set-Cookie "miq_oidc_access_token=%{OIDC_access_token}e; Max-Age=10; Path=/ui/service"
+  FileETag  None
+  Header    Set Cache-Control "max-age=0, no-store, no-cache, must-revalidate"
+  Header    Set Pragma "no-cache"
+  Header    Set Set-Cookie "miq_oidc_access_token=%{OIDC_access_token}e; Max-Age=10; Path=/ui/service"
+  Header    Unset ETag
 </Location>
 
 <LocationMatch ^/api(?!\/(v[\d\.]+\/)?product_info$)>


### PR DESCRIPTION
set headers so these ssl pages are not cached

related to https://github.com/ManageIQ/manageiq-pods/pull/727