### PR TITLE
[LASKER] [/etc/default/evm] ANSIBLE_LOCAL_TEMP/ANSIBLE_REMOTE_TEMP

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -12,6 +12,10 @@ export MALLOC_ARENA_MAX=1
 # Location of certificates and provider keys
 export KEY_ROOT=/var/www/miq/vmdb/certs
 
+# Ansible global variables
+export ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp
+export ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
+
 [[ -s /etc/default/evm_ruby ]] && source /etc/default/evm_ruby
 [[ -s /etc/default/evm_postgres ]] && source /etc/default/evm_postgres
 source /etc/default/evm_production


### PR DESCRIPTION
Lasker version of https://github.com/ManageIQ/manageiq-appliance/pull/319

Adds ENV variables for `remote_tmp` and `local_tmp`.  This fixes an issue on podified where `~/.ansible/tmp` is not writable since `~/` is actually `/` for our linux user.  Error output looks something like this:

```
Unhandled error:
 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 90, in makedirs_safe
    os.makedirs(b_rpath, mode)
  File "/usr/lib64/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib64/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: b'/.ansible'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 572, in update_config_data
    value, origin = self.get_config_value_and_origin(config, configfile)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 516, in get_config_value_and_origin
    value = ensure_type(value, defs[config].get('type'), origin=origin)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 122, in ensure_type
    makedirs_safe(value, 0o700)
  File "/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 95, in makedirs_safe
    raise AnsibleError("Unable to create local directories(%s): %s" % (to_native(rpath), to_native(e)))
ansible.errors.AnsibleError: Unable to create local directories(/.ansible/tmp): [Errno 13] Permission denied: b'/.ansible'
Traceback (most recent call last):
  File "c/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 90, in makedirs_safe
    os.makedirs(b_rpath, mode)
  File "/usr/lib64/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib64/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: b'/.ansible'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 572, in update_config_data
    value, origin = self.get_config_value_and_origin(config, configfile)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 516, in get_config_value_and_origin
    value = ensure_type(value, defs[config].get('type'), origin=origin)
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 122, in ensure_type
    makedirs_safe(value, 0o700)
  File "/usr/lib/python3.6/site-packages/ansible/utils/path.py", line 95, in makedirs_safe
    raise AnsibleError("Unable to create local directories(%s): %s" % (to_native(rpath), to_native(e)))
ansible.errors.AnsibleError: Unable to create local directories(/.ansible/tmp): [Errno 13] Permission denied: b'/.ansible'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 62, in <module>
    import ansible.constants as C
  File "/usr/lib/python3.6/site-packages/ansible/constants.py", line 175, in <module>
    config = ConfigManager()
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 291, in __init__
    self.update_config_data()
  File "/usr/lib/python3.6/site-packages/ansible/config/manager.py", line 584, in update_config_data
    raise AnsibleError("Invalid settings supplied for %s: %s\n" % (config, to_native(e)), orig_exc=e)
ansible.errors.AnsibleError: Invalid settings supplied for DEFAULT_LOCAL_TMP: Unable to create local directories(/.ansible/tmp): [Errno 13] Permission denied: b'/.ansible'
```

Switching to `/tmp/.ansible_local_tmp` and `/tmp/.ansible_remote_tmp` should allow this most playbooks that had issues writing to those respective `tmp` dirs to now do it.  We are keeping this consistent across podified and appliance builds since it shouldn't cause an issue with appliances doing the same thing.


Links
-----

* Comments on the original commit (without a branch):  https://github.com/ManageIQ/manageiq/commit/ac6f4d8d3ac0d431264724dc75a32e90b6407f2e#commitcomment-52455378
* Ansible config link:  https://github.com/ansible/ansible/blob/ad203a7dbdbcab9af0b89a577433af860b542e01/examples/ansible.cfg#L4-L8