### PR TITLE
Declare memcached as a dependency for evmserverd

### DIFF
--- a/COPY/usr/lib/systemd/system/evmserverd.service
+++ b/COPY/usr/lib/systemd/system/evmserverd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=EVM server daemon
-After=syslog.target
+After=syslog.target memcached.service
+Wants=memcached.service
 
 [Service]
 WorkingDirectory=/var/www/miq/vmdb


### PR DESCRIPTION
Start evmserverd after memcached, this can replace our `MiqServer.start_memcached` in `lib/workers/evm_server.rb`