### PR TITLE
let rpm install cable

### DIFF
--- a/manageiq-setup.sh
+++ b/manageiq-setup.sh
@@ -70,6 +70,3 @@ semodule -i /tmp/cockpit_ws_miq.pp
 # will remove this once app is no longer running as root
 /usr/sbin/semanage fcontext -a -t user_home_dir_t "/root(/)?"
 /sbin/restorecon /root
-
-# ActionCable configuration
-cp /var/www/miq/vmdb/config/cable.yml.sample /var/www/miq/vmdb/config/cable.yml


### PR DESCRIPTION
this is part of https://github.com/ManageIQ/manageiq/issues/21295

the action cable.yml file is placed by the rpm
no need to do it at appliance build time in `manageiq-setup.sh`