### PR TITLE
Put our ansible roles in standard location

### DIFF
--- a/LINK/root/.ansible.cfg
+++ b/LINK/root/.ansible.cfg
@@ -1,3 +1,0 @@
-[defaults]
-stdout_callback = json
-roles_path = /root/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/var/www/miq/vmdb/content/ansible_consolidated/roles


### PR DESCRIPTION
related: https://github.com/ManageIQ/manageiq-rpm_build/pull/159

using standard ansible configuration and removed special
configuration file.

we removed this to get away from a root specific configuration
which is necessary as we go towards running this as manageiq user