### PR TITLE
use shell primitives for /etc/default/evm

### DIFF
--- a/LINK/etc/default/evm
+++ b/LINK/etc/default/evm
@@ -3,11 +3,13 @@
 # Description: Sets the environment for scripts and console users
 #
 
+# for all properties files
+#   set variables from all lines (skipping comments and blank lines)
+# see systemd EnvironmentFile for info on the file format
 for prop in /etc/default/*.properties ; do
-  if [[ -e ${prop} ]] ; then
-    # lines starting with a semi or a # are ignored
-    export $(sed -e 's/^[#;].*//g' ${prop} | xargs)
-  else
-    echo "missing evm properties file: ${prop}"
-  fi
+  while read -r line ; do
+    if [[ ! $line =~ ^(#|;|$) ]] ; then
+      export $line
+    fi
+  done < $prop
 done


### PR DESCRIPTION
I was reading the results from https://github.com/ManageIQ/manageiq-pods/issues/695 and realized that we could do quite a bit to speed this up.

Spawning `sed` and `xargs` a few times is not that slow, but since containers call this often, it makes sense to make it 5x faster. (the numbers are small enough that there is definite rounding issues)

In an appliance, we directly access `*.properties` from systemd, so most (all?) of the lines with `source /etc/default/evm` should be removed. But in the container case, this makes the most sense.

ALTERNATE: If this is too much, removing the `for` and `xargs` and moving `manageiq*.properties` to `sed` makes it 2x faster.

TL;DR: `source /etc/default/evm` now takes 1-2ms down from 9-10ms (84% faster)

High Level Results
----

## Before

```
[root@localhost ~]# time source /etc/default/evm

real	0m0.009s
user	0m0.005s
sys	0m0.005s
[root@localhost ~]# time source /etc/default/evm

real	0m0.009s
user	0m0.005s
sys	0m0.006s
[root@localhost ~]# time source /etc/default/evm

real	0m0.009s
user	0m0.006s
sys	0m0.004s
[root@localhost ~]# time source /etc/default/evm

real	0m0.010s
user	0m0.005s
sys	0m0.007s
```

## After

```
[root@localhost ~]# time source /etc/default/evm3

real	0m0.002s
user	0m0.002s
sys	0m0.000s
[root@localhost ~]# time source /etc/default/evm3

real	0m0.002s
user	0m0.002s
sys	0m0.000s
[root@localhost ~]# time source /etc/default/evm3

real	0m0.001s
user	0m0.001s
sys	0m0.000s
[root@localhost ~]# time source /etc/default/evm3

real	0m0.001s
user	0m0.000s
sys	0m0.001s
[root@localhost ~]# time source /etc/default/evm3

real	0m0.002s
user	0m0.001s
sys	0m0.000s
```

Low Level Results
-------

Reminder: The new version has more lines in the results because it is doing everything in bash.

```
PS4='+ $(date "+%s.%N")\011 '
set -x
```

## Before

```
+ 1630776598.575243116	 source /etc/default/evm
++ 1630776598.577724492	 for prop in /etc/default/*.properties
++ 1630776598.580407113	 [[ -e /etc/default/manageiq-productization.properties ]]
+++ 1630776598.583159608	 sed -e 's/^[#;].*//g' /etc/default/manageiq-productization.properties
+++ 1630776598.583299561	 xargs
++ 1630776598.588585935	 export APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance APPLIANCE_TEMPLATE_DIRECTORY=/opt/manageiq/manageiq-appliance/TEMPLATE GEM_HOME=/opt/manageiq/manageiq-gemset GEM_PATH=/opt/manageiq/manageiq-gemset:/usr/share/gems:/usr/local/share/gems PATH=/opt/manageiq/manageiq-gemset/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
++ 1630776598.590573902	 APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance
++ 1630776598.592449695	 APPLIANCE_TEMPLATE_DIRECTORY=/opt/manageiq/manageiq-appliance/TEMPLATE
++ 1630776598.594580603	 GEM_HOME=/opt/manageiq/manageiq-gemset
++ 1630776598.596351212	 GEM_PATH=/opt/manageiq/manageiq-gemset:/usr/share/gems:/usr/local/share/gems
++ 1630776598.598040559	 PATH=/opt/manageiq/manageiq-gemset/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
++ 1630776598.599777013	 for prop in /etc/default/*.properties
++ 1630776598.601627936	 [[ -e /etc/default/manageiq.properties ]]
+++ 1630776598.603716875	 sed -e 's/^[#;].*//g' /etc/default/manageiq.properties
+++ 1630776598.603810343	 xargs
++ 1630776598.607866839	 export RAILS_ENV=production APPLIANCE=true EXECJS_RUNTIME=Node MALLOC_ARENA_MAX=1 KEY_ROOT=/var/www/miq/vmdb/certs BUNDLE_GEMFILE=/var/www/miq/vmdb/Gemfile LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 APPLIANCE_PG_CTL=/usr/bin/pg_ctl APPLIANCE_PG_MOUNT_POINT=/var/lib/pgsql APPLIANCE_PG_DATA=/var/lib/pgsql/data APPLIANCE_PG_SERVICE=postgresql APPLIANCE_PG_PACKAGE_NAME=postgresql-server RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000 RUBY_GC_HEAP_INIT_SLOTS=600000 RUBY_GC_HEAP_GROWTH_FACTOR=1.25 ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
++ 1630776598.609421813	 RAILS_ENV=production
++ 1630776598.610947985	 APPLIANCE=true
++ 1630776598.612792037	 EXECJS_RUNTIME=Node
++ 1630776598.614410047	 MALLOC_ARENA_MAX=1
++ 1630776598.615933145	 KEY_ROOT=/var/www/miq/vmdb/certs
++ 1630776598.617492804	 BUNDLE_GEMFILE=/var/www/miq/vmdb/Gemfile
++ 1630776598.618909222	 LANGUAGE=en_US.UTF-8
++ 1630776598.620510189	 LANG=en_US.UTF-8
++ 1630776598.621956358	 LC_CTYPE=en_US.UTF-8
++ 1630776598.623538905	 APPLIANCE_PG_CTL=/usr/bin/pg_ctl
++ 1630776598.624930677	 APPLIANCE_PG_MOUNT_POINT=/var/lib/pgsql
++ 1630776598.626499465	 APPLIANCE_PG_DATA=/var/lib/pgsql/data
++ 1630776598.627945505	 APPLIANCE_PG_SERVICE=postgresql
++ 1630776598.629471510	 APPLIANCE_PG_PACKAGE_NAME=postgresql-server
++ 1630776598.630953073	 RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
++ 1630776598.632551942	 RUBY_GC_HEAP_INIT_SLOTS=600000
++ 1630776598.634291091	 RUBY_GC_HEAP_GROWTH_FACTOR=1.25
++ 1630776598.635762367	 ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp
++ 1630776598.637303681	 ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
++ 1630776598.638806036	 printf '\033]0;%s@%s:%s\007' root localhost '~'
```

## final (shell primitives)

```
+ 1630776659.304582724	 source /etc/default/evm3
++ 1630776659.306331189	 for prop in /etc/default/*.properties
++ 1630776659.308809414	 read -r line
++ 1630776659.310862540	 [[ ! APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance =~ ^(#|;|$) ]]
++ 1630776659.312883173	 export APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance
++ 1630776659.314748599	 APPLIANCE_SOURCE_DIRECTORY=/opt/manageiq/manageiq-appliance
++ 1630776659.316600062	 read -r line
++ 1630776659.318351281	 [[ ! APPLIANCE_TEMPLATE_DIRECTORY=/opt/manageiq/manageiq-appliance/TEMPLATE =~ ^(#|;|$) ]]
++ 1630776659.320068336	 export APPLIANCE_TEMPLATE_DIRECTORY=/opt/manageiq/manageiq-appliance/TEMPLATE
++ 1630776659.321813808	 APPLIANCE_TEMPLATE_DIRECTORY=/opt/manageiq/manageiq-appliance/TEMPLATE
++ 1630776659.323492053	 read -r line
++ 1630776659.325075684	 [[ ! GEM_HOME=/opt/manageiq/manageiq-gemset =~ ^(#|;|$) ]]
++ 1630776659.326690355	 export GEM_HOME=/opt/manageiq/manageiq-gemset
++ 1630776659.328277029	 GEM_HOME=/opt/manageiq/manageiq-gemset
++ 1630776659.329780447	 read -r line
++ 1630776659.331337679	 [[ ! GEM_PATH=/opt/manageiq/manageiq-gemset:/usr/share/gems:/usr/local/share/gems =~ ^(#|;|$) ]]
++ 1630776659.332789660	 export GEM_PATH=/opt/manageiq/manageiq-gemset:/usr/share/gems:/usr/local/share/gems
++ 1630776659.334334802	 GEM_PATH=/opt/manageiq/manageiq-gemset:/usr/share/gems:/usr/local/share/gems
++ 1630776659.335726218	 read -r line
++ 1630776659.337156810	 [[ ! PATH=/opt/manageiq/manageiq-gemset/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin =~ ^(#|;|$) ]]
++ 1630776659.338697674	 export PATH=/opt/manageiq/manageiq-gemset/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
++ 1630776659.340168911	 PATH=/opt/manageiq/manageiq-gemset/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
++ 1630776659.341637446	 read -r line
++ 1630776659.343081430	 for prop in /etc/default/*.properties
++ 1630776659.344694143	 read -r line
++ 1630776659.346154249	 [[ ! RAILS_ENV=production =~ ^(#|;|$) ]]
++ 1630776659.347636527	 export RAILS_ENV=production
++ 1630776659.349109779	 RAILS_ENV=production
++ 1630776659.350695721	 read -r line
++ 1630776659.352147960	 [[ ! APPLIANCE=true =~ ^(#|;|$) ]]
++ 1630776659.353651863	 export APPLIANCE=true
++ 1630776659.355399077	 APPLIANCE=true
++ 1630776659.356862319	 read -r line
++ 1630776659.358416319	 [[ ! # Force ExecJS to use node =~ ^(#|;|$) ]]
++ 1630776659.359909712	 read -r line
++ 1630776659.361386673	 [[ ! EXECJS_RUNTIME='Node' =~ ^(#|;|$) ]]
++ 1630776659.362830127	 export 'EXECJS_RUNTIME='\''Node'\'''
++ 1630776659.364315241	 EXECJS_RUNTIME=''\''Node'\'''
++ 1630776659.365688453	 read -r line
++ 1630776659.367073871	 [[ ! # workaround for virtual memory spike observed with RHEL6 =~ ^(#|;|$) ]]
++ 1630776659.368569435	 read -r line
++ 1630776659.370057761	 [[ ! MALLOC_ARENA_MAX=1 =~ ^(#|;|$) ]]
++ 1630776659.371516430	 export MALLOC_ARENA_MAX=1
++ 1630776659.372946404	 MALLOC_ARENA_MAX=1
++ 1630776659.374429581	 read -r line
++ 1630776659.375819405	 [[ ! # Location of certificates and provider keys (miq-password and appliance console) =~ ^(#|;|$) ]]
++ 1630776659.377328215	 read -r line
++ 1630776659.378666905	 [[ ! KEY_ROOT=/var/www/miq/vmdb/certs =~ ^(#|;|$) ]]
++ 1630776659.380041512	 export KEY_ROOT=/var/www/miq/vmdb/certs
++ 1630776659.381431631	 KEY_ROOT=/var/www/miq/vmdb/certs
++ 1630776659.382762213	 read -r line
++ 1630776659.384246945	 [[ ! BUNDLE_GEMFILE=/var/www/miq/vmdb/Gemfile =~ ^(#|;|$) ]]
++ 1630776659.385705596	 export BUNDLE_GEMFILE=/var/www/miq/vmdb/Gemfile
++ 1630776659.387378299	 BUNDLE_GEMFILE=/var/www/miq/vmdb/Gemfile
++ 1630776659.389052523	 read -r line
++ 1630776659.390606570	 [[ ! '' =~ ^(#|;|$) ]]
++ 1630776659.392160697	 read -r line
++ 1630776659.393479480	 [[ ! # Force locale =~ ^(#|;|$) ]]
++ 1630776659.394802052	 read -r line
++ 1630776659.396146305	 [[ ! LANGUAGE=en_US.UTF-8 =~ ^(#|;|$) ]]
++ 1630776659.397796752	 export LANGUAGE=en_US.UTF-8
++ 1630776659.399348903	 LANGUAGE=en_US.UTF-8
++ 1630776659.400964856	 read -r line
++ 1630776659.402745094	 [[ ! LANG=en_US.UTF-8 =~ ^(#|;|$) ]]
++ 1630776659.404349248	 export LANG=en_US.UTF-8
++ 1630776659.405873866	 LANG=en_US.UTF-8
++ 1630776659.407487854	 read -r line
++ 1630776659.408919494	 [[ ! LC_CTYPE=en_US.UTF-8 =~ ^(#|;|$) ]]
++ 1630776659.410783917	 export LC_CTYPE=en_US.UTF-8
++ 1630776659.412337741	 LC_CTYPE=en_US.UTF-8
++ 1630776659.413729104	 read -r line
++ 1630776659.415180165	 [[ ! '' =~ ^(#|;|$) ]]
++ 1630776659.416711999	 read -r line
++ 1630776659.418103497	 [[ ! # Postgres (appliance console, PgAdmin) =~ ^(#|;|$) ]]
++ 1630776659.419632972	 read -r line
++ 1630776659.421407512	 [[ ! APPLIANCE_PG_CTL=/usr/bin/pg_ctl =~ ^(#|;|$) ]]
++ 1630776659.422882304	 export APPLIANCE_PG_CTL=/usr/bin/pg_ctl
++ 1630776659.424448934	 APPLIANCE_PG_CTL=/usr/bin/pg_ctl
++ 1630776659.425863178	 read -r line
++ 1630776659.427320604	 [[ ! APPLIANCE_PG_MOUNT_POINT=/var/lib/pgsql =~ ^(#|;|$) ]]
++ 1630776659.428682395	 export APPLIANCE_PG_MOUNT_POINT=/var/lib/pgsql
++ 1630776659.430015932	 APPLIANCE_PG_MOUNT_POINT=/var/lib/pgsql
++ 1630776659.431515881	 read -r line
++ 1630776659.432963050	 [[ ! APPLIANCE_PG_DATA=/var/lib/pgsql/data =~ ^(#|;|$) ]]
++ 1630776659.434528097	 export APPLIANCE_PG_DATA=/var/lib/pgsql/data
++ 1630776659.435863772	 APPLIANCE_PG_DATA=/var/lib/pgsql/data
++ 1630776659.437443010	 read -r line
++ 1630776659.438836450	 [[ ! APPLIANCE_PG_SERVICE=postgresql =~ ^(#|;|$) ]]
++ 1630776659.440167847	 export APPLIANCE_PG_SERVICE=postgresql
++ 1630776659.441864717	 APPLIANCE_PG_SERVICE=postgresql
++ 1630776659.443367755	 read -r line
++ 1630776659.444770825	 [[ ! APPLIANCE_PG_PACKAGE_NAME=postgresql-server =~ ^(#|;|$) ]]
++ 1630776659.446288953	 export APPLIANCE_PG_PACKAGE_NAME=postgresql-server
++ 1630776659.447856759	 APPLIANCE_PG_PACKAGE_NAME=postgresql-server
++ 1630776659.449373626	 read -r line
++ 1630776659.450757755	 [[ ! '' =~ ^(#|;|$) ]]
++ 1630776659.452370136	 read -r line
++ 1630776659.453803766	 [[ ! # Configure the ruby 2.1+ garbage collector with initial values =~ ^(#|;|$) ]]
++ 1630776659.455263979	 read -r line
++ 1630776659.456734103	 [[ ! # based on research found here: http://tmm1.net/ruby21-rgengc/ =~ ^(#|;|$) ]]
++ 1630776659.458154307	 read -r line
++ 1630776659.459602400	 [[ ! # =~ ^(#|;|$) ]]
++ 1630776659.460956708	 read -r line
++ 1630776659.462439622	 [[ ! # bundle exec rails r "GC.start; puts GC.stat.values_at(:count, :heap_live_slots)" =~ ^(#|;|$) ]]
++ 1630776659.463785276	 read -r line
++ 1630776659.465201514	 [[ ! #   before: =~ ^(#|;|$) ]]
++ 1630776659.466687556	 read -r line
++ 1630776659.468052518	 [[ ! #     42     # run gc 42 times (minor and major) =~ ^(#|;|$) ]]
++ 1630776659.469483003	 read -r line
++ 1630776659.470881395	 [[ ! #     461247 # live slots after a full GC =~ ^(#|;|$) ]]
++ 1630776659.472439516	 read -r line
++ 1630776659.473853356	 [[ ! #   after: =~ ^(#|;|$) ]]
++ 1630776659.475323474	 read -r line
++ 1630776659.476679652	 [[ ! #     17 =~ ^(#|;|$) ]]
++ 1630776659.478084942	 read -r line
++ 1630776659.479524594	 [[ ! #     461103 =~ ^(#|;|$) ]]
++ 1630776659.480892956	 read -r line
++ 1630776659.482452312	 [[ ! # =~ ^(#|;|$) ]]
++ 1630776659.483931941	 read -r line
++ 1630776659.485484500	 [[ ! # default: run GC while actively allocating objects (we want this) =~ ^(#|;|$) ]]
++ 1630776659.486908830	 read -r line
++ 1630776659.488439387	 [[ ! # RUBY_GC_HEAP_FREE_SLOTS=4095 =~ ^(#|;|$) ]]
++ 1630776659.489886254	 read -r line
++ 1630776659.491404488	 [[ ! # default: unlimited growth =~ ^(#|;|$) ]]
++ 1630776659.492950069	 read -r line
++ 1630776659.494774142	 [[ ! RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000 =~ ^(#|;|$) ]]
++ 1630776659.496213492	 export RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
++ 1630776659.497786595	 RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000
++ 1630776659.499163127	 read -r line
++ 1630776659.500529226	 [[ ! # default: 10000 - set to the minimal number of slots needed =~ ^(#|;|$) ]]
++ 1630776659.502041853	 read -r line
++ 1630776659.503508755	 [[ ! RUBY_GC_HEAP_INIT_SLOTS=600000 =~ ^(#|;|$) ]]
++ 1630776659.504943919	 export RUBY_GC_HEAP_INIT_SLOTS=600000
++ 1630776659.506743717	 RUBY_GC_HEAP_INIT_SLOTS=600000
++ 1630776659.508323612	 read -r line
++ 1630776659.509806171	 [[ ! # default: 1.8 - smaller number means growing slower =~ ^(#|;|$) ]]
++ 1630776659.511284825	 read -r line
++ 1630776659.512789485	 [[ ! RUBY_GC_HEAP_GROWTH_FACTOR=1.25 =~ ^(#|;|$) ]]
++ 1630776659.514184814	 export RUBY_GC_HEAP_GROWTH_FACTOR=1.25
++ 1630776659.515640004	 RUBY_GC_HEAP_GROWTH_FACTOR=1.25
++ 1630776659.516981542	 read -r line
++ 1630776659.518558245	 [[ ! '' =~ ^(#|;|$) ]]
++ 1630776659.520001124	 read -r line
++ 1630776659.521486894	 [[ ! # Ansible global variables =~ ^(#|;|$) ]]
++ 1630776659.522906616	 read -r line
++ 1630776659.524396890	 [[ ! ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp =~ ^(#|;|$) ]]
++ 1630776659.525749430	 export ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp
++ 1630776659.527086087	 ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp
++ 1630776659.528646559	 read -r line
++ 1630776659.530013144	 [[ ! ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp =~ ^(#|;|$) ]]
++ 1630776659.531557319	 export ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
++ 1630776659.532904806	 ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
++ 1630776659.534428435	 read -r line
++ 1630776659.535896163	 printf '\033]0;%s@%s:%s\007' root localhost '~'
```
