### PR TITLE
[MORPHY] Don't configure ManageIQ to use an internal kafka server at boot

### DIFF
--- a/LINK/usr/bin/manageiq-initialize.sh
+++ b/LINK/usr/bin/manageiq-initialize.sh
@@ -3,4 +3,3 @@
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 echo "Initializing Appliance, please wait ..." > /dev/tty1
 appliance_console_cli --region 0 --internal --password smartvm --key
-appliance_console_cli --message-server-config --message-server-use-ipaddr --message-keystore-username="admin" --message-keystore-password="smartvm"


### PR DESCRIPTION
Based on #316 backport