### PR TITLE
Fix execjs runtime error

### DIFF
--- a/LINK/etc/default/manageiq.properties
+++ b/LINK/etc/default/manageiq.properties
@@ -1,7 +1,7 @@
 RAILS_ENV=production
 APPLIANCE=true
 # Force ExecJS to use node
-EXECJS_RUNTIME='Node'
+EXECJS_RUNTIME=Node
 # workaround for virtual memory spike observed with RHEL6
 MALLOC_ARENA_MAX=1
 # Location of certificates and provider keys (miq-password and appliance console)


### PR DESCRIPTION
The EXECJS_RUNTIME env var has to be `Node` not `'Node'` otherwise execjs raises an exception

```ruby
/opt/manageiq/manageiq-gemset/gems/execjs-2.8.1/lib/execjs/runtimes.rb:70:in `const_defined?': wrong constant name 'Node' (NameError)
	from /opt/manageiq/manageiq-gemset/gems/execjs-2.8.1/lib/execjs/runtimes.rb:70:in `from_environment'
	from /opt/manageiq/manageiq-gemset/gems/execjs-2.8.1/lib/execjs/runtimes.rb:57:in `autodetect'
```

```bash
echo $EXECJS_RUNTIME
'Node'
```

Replaced with `EXECJS_RUNTIME=node` and able to load rails successfully

Appears to have been introduced by https://github.com/ManageIQ/manageiq-appliance/pull/309, unclear why I only see it failing within the last week or so