### PR TITLE
Tell postgres client to use OS cert bundle for ssl root keys

### DIFF
--- a/COPY/etc/default/manageiq.properties
+++ b/COPY/etc/default/manageiq.properties
@@ -43,3 +43,6 @@ RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 # Ansible global variables
 ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp
 ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
+
+# libpg uses operating system certificate bundle
+PGSSLROOTCERT=/etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
### Goal

Part of larger PR https://github.com/ManageIQ/manageiq/issues/20394

Enables:

- [x] [documentation](https://github.com/ManageIQ/manageiq-documentation/pull/1617)

Transitioning from root to other users means we don't store key configuration files in `/root`
Luckily, the operating system has a mechanism for storing ca certs in a centralized location.

This PR is focused on connecting to the database and encrypting traffic using ssl.

### Before

- putting the database self signed cert, or the company CA cert into `/root/.postgres/root.crt`
- broken for manageiq user.
- pod puts the cert into the OS location. see: https://github.com/ManageIQ/manageiq/pull/21386
- pods hacks `~/.postgres/root` so the CA cert will register. [orchestrator.go:176](https://github.com/ManageIQ/manageiq-pods/blob/196c657da322c4ee8d7406d791555345c2b73ebb/manageiq-operator/pkg/helpers/miq-components/orchestrator.go#L176-L179)

### After

- appliances (and pods) put the self signed cert and/or company CA cert into `/etc/pki/tis/certs/ca-bundle.crt`
- works for root and manageiq usersl
- removes extra configuration step in orchestrator since postgres (`libpg`) will pick it up from `/etc`.

### Appliance Reproduction steps

```bash
echo PGSSLROOTCERT=/etc/pki/tls/certs/ca-bundle.crt > /etc/default/miq.properties
source /etc/default/evm
rm -rf ~/.postgresql # nothing up my sleeves.

# #include(setup db with self signed ca cert) note: cert hostname must be $DATABASE
DATABASE=db-appliance

#echo "$DATABASE 127.0.0.1" > /etc/hosts
#cp /var/www/miq/vmdb/certs/root.crt /etc/pki/ca-trust/source/$DATABASE
scp root@$DATABASE:/var/www/miq/vmdb/certs/root.crt /etc/pki/ca-trust/source/$DATABASE

update-ca-trust extract

PGSSLMODE=verify-full psql -h $DATABASE -d vmdb_production
```

### Bibliography

- https://github.com/ManageIQ/manageiq/pull/21386
- https://github.com/ManageIQ/manageiq-pods/blob/master/manageiq-operator/pkg/helpers/miq-components/orchestrator.go#L176
- pods depends upon us creating this file. but this is a totally different environment https://github.com/ManageIQ/manageiq/blob/master/lib/container_orchestrator/object_definition.rb#L29