### PR TITLE
fix quoted strings in properties files

### DIFF
--- a/COPY/etc/default/evm
+++ b/COPY/etc/default/evm
@@ -2,14 +2,21 @@
 #
 # Description: Sets the environment for scripts and console users
 #
-
 # for all properties files
-#   set variables from all lines (skipping comments and blank lines)
-# see systemd EnvironmentFile for info on the file format
+#   prune off comment portion of line
+#   pull off variable and the value (remove trailing spaces)
+#   export the variable
+#
 for prop in /etc/default/*.properties ; do
   while read -r line ; do
-    if [[ ! $line =~ ^(#|;|$) ]] ; then
-      export $line
+    line=${line%% #*}
+    if [[ $line =~ ^([A-Za-z0-9_]*)\ *=\ *[\"\']?([^\"\']*)[\"\']?\ *$ ]] ; then
+      VAR="${BASH_REMATCH[1]}"
+      VALUE="${BASH_REMATCH[2]}"
+      VALUE="${VALUE%% *}"
+      export ${VAR}="${VALUE}"
+    elif [[ -n "$line" && ! $line =~ ^\ *#.*$ ]] ; then 
+      echo "bad property in ${prop}: ${line}" >&2
     fi
   done < $prop
 done


### PR DESCRIPTION
## Issue

We want the ability to have quoted strings in our `/etc/defalt/manageiq.properties` files. Unfortunately

```
# manageiq.properties
A='a'

# produces
echo $A
'a'

# desired
echo $A
a

```

This was introduced in #329

## Solution

`eval` properly sets the property value,
and `export` exposes the variable outside the shell to other processes

## test run

```
[root@localhost ~]# cat /etc/default/manageiq-test.properties
A=a
B="b b"
C='c' # this is c

[root@localhost ~]# . /etc/default/evm        # <== before
-bash: export: `b"': not a valid identifier
-bash: export: `#': not a valid identifier

[root@localhost ~]# . /etc/default/evm        # <== after
[root@localhost ~]# echo "'$A' '$B' '$C'"
'a' 'b b' 'c'

[root@localhost ~]# time . /etc/default/evm

real	0m0.002s
user	0m0.002s
sys	0m0.000s
```

## Other changes

As seen for example `c` above, trailing comments on a line of a file are now ignored.

Fixes #335
