### PR TITLE
Revert "Tell postgres client to use OS cert bundle for ssl root keys"

### DIFF
--- a/COPY/etc/default/manageiq.properties
+++ b/COPY/etc/default/manageiq.properties
@@ -43,6 +43,3 @@ RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 # Ansible global variables
 ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp
 ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
-
-# libpg uses operating system certificate bundle
-PGSSLROOTCERT=/etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
This change reverts https://github.com/ManageIQ/manageiq-appliance/pull/341