### PR TITLE
Prevent logrotate from creating 0644 log files

### DIFF
--- a/COPY/etc/logrotate.d/miq_logs.conf
+++ b/COPY/etc/logrotate.d/miq_logs.conf
@@ -1,4 +1,18 @@
-/var/www/miq/vmdb/log/*.log /var/www/miq/vmdb/log/apache/*.log /var/lib/pgsql/data/log/*.log /var/log/tower/*.log {
+/var/www/miq/vmdb/log/*.log {
+  daily
+  dateext
+  missingok
+  rotate 14
+  notifempty
+  compress
+  copytruncate
+  create 0660 manageiq manageiq
+  prerotate
+    source /etc/default/evm; /bin/sh ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh $1
+  endscript
+}
+
+/var/www/miq/vmdb/log/apache/*.log /var/lib/pgsql/data/log/*.log /var/log/tower/*.log {
   daily
   dateext
   missingok


### PR DESCRIPTION
~~WIP pending a live test on an appliance, this runs without error but I want to test it after rotating log files which takes a day by default~~

https://github.com/ManageIQ/manageiq-appliance/issues/349