### PR TITLE
Fix initial permissions of log files

### DIFF
--- a/COPY/usr/bin/evminit.sh
+++ b/COPY/usr/bin/evminit.sh
@@ -5,15 +5,9 @@
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 
-# Some variables to shorten things
-VMDBDIR=/var/www/miq/vmdb
-EVMLOG=$VMDBDIR/log/evm.log
-PID_DIR=$VMDBDIR/tmp/pids
-
-
 # Log to evm.log that appliance booted
-echo `date -u` 'EVMINIT   EVM Appliance Booted' >> $EVMLOG
-rm -rfv $PID_DIR/evm.pid >> $EVMLOG
+echo `date -u` 'EVMINIT   EVM Appliance Booted'
+rm -rfv /var/www/miq/vmdb/tmp/pids/evm.pid
 
 # Generate certs/server.cer if it doesn't exist
 /usr/bin/generate_miq_server_cert.sh


### PR DESCRIPTION
When the appliance initially starts the log files in /var/www/miq/vmdb/log/*.log are created by various initialization utilities.  Today these utilities create log files with invalid permissions preventing workers from starting up when running as the manageiq user.

TODO:
- [x] evminit.sh
~~- [ ] manageiq-initialize.sh~~

https://github.com/ManageIQ/manageiq-appliance/issues/349