### PR TITLE
Rename the evminit.service description

### DIFF
--- a/COPY/usr/lib/systemd/system/evminit.service
+++ b/COPY/usr/lib/systemd/system/evminit.service
@@ -1,5 +1,5 @@
 [Unit]
-Description="Initializes the evm environment"
+Description="Initialize the evm environment"
 After=syslog.target
 
 [Service]


### PR DESCRIPTION
This reads oddly in the logs, `Started "Initializes the evm environment".`