### PR TITLE
[NAJDORF] Disable automatic configuration of kafka

### DIFF
--- a/COPY/usr/bin/manageiq-initialize.sh
+++ b/COPY/usr/bin/manageiq-initialize.sh
@@ -3,4 +3,3 @@
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 echo "Initializing Appliance, please wait ..." > /dev/tty1
 appliance_console_cli --region 0 --internal --password smartvm --key
-appliance_console_cli --message-server-config --message-server-use-ipaddr --message-keystore-username="admin" --message-keystore-password="smartvm"


### PR DESCRIPTION
Kafka is not currently used by MIQ and the version installed contains a
security vulnerability.  Disable automatic configuration of kafka for
messaging for now.