### PR TITLE
Update appliance_console for kafka check changes

### DIFF
--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,2 +1,2 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
-gem "manageiq-appliance_console", "~>7.0", ">=7.0.2", :require => false
+gem "manageiq-appliance_console", "~>7.0", ">=7.0.3", :require => false


### PR DESCRIPTION
Update appliance console to check if kafka is installed prior to allowing messaging client/server config.