### PR TITLE
increase appliance_console version to 7.0.4

### DIFF
--- a/manageiq-appliance-dependencies.rb
+++ b/manageiq-appliance-dependencies.rb
@@ -1,2 +1,2 @@
 # Add gems here, in Gemfile syntax, which are dependencies of the appliance itself rather than a part of the ManageIQ application
-gem "manageiq-appliance_console", "~>7.0", ">=7.0.3", :require => false
+gem "manageiq-appliance_console", "~>7.0", ">=7.0.4", :require => false


### PR DESCRIPTION
We now create our region slightly differently.
So both manageiq and appliance console changed to reflect the new
interface

Part of https://github.com/ManageIQ/manageiq/pull/21981