### PR TITLE
Server certs need to be readable by user and group

### DIFF
--- a/COPY/usr/bin/generate_miq_server_cert.sh
+++ b/COPY/usr/bin/generate_miq_server_cert.sh
@@ -5,5 +5,5 @@ CERT="${NEW_CERT_FILE:-/var/www/miq/vmdb/certs/server.cer}"
 KEY="${NEW_KEY_FILE:-$CERT.key}"
 if [ ! -f "$CERT" -a ! -f "$KEY" ]; then
   openssl req -x509 -newkey rsa -days 1095 -keyout $KEY -out $CERT -subj "/CN=server" -nodes -batch
-  chmod 0660 $CERT $KEY
+  chmod 0640 $CERT $KEY
 fi

--- a/COPY/usr/bin/generate_miq_server_cert.sh
+++ b/COPY/usr/bin/generate_miq_server_cert.sh
@@ -4,5 +4,6 @@ set -e -o pipefail
 CERT="${NEW_CERT_FILE:-/var/www/miq/vmdb/certs/server.cer}"
 KEY="${NEW_KEY_FILE:-$CERT.key}"
 if [ ! -f "$CERT" -a ! -f "$KEY" ]; then
-  (umask 077 ; openssl req -x509 -newkey rsa -days 1095 -keyout $KEY -out $CERT -subj "/CN=server" -nodes -batch)
+  openssl req -x509 -newkey rsa -days 1095 -keyout $KEY -out $CERT -subj "/CN=server" -nodes -batch
+  chmod 0660 $CERT $KEY
 fi


### PR DESCRIPTION
The server certificate is used by httpd (running as root) and MiqRemoteConsoleWorker (running as manageiq).

https://github.com/ManageIQ/manageiq/issues/22065