### PR TITLE
Set sensible psql host/port defaults or let psql do it.

### DIFF
--- a/COPY/usr/bin/manageiq-db-ready
+++ b/COPY/usr/bin/manageiq-db-ready
@@ -13,7 +13,9 @@ end
 
 def database_ready?(db_yaml, env = "production")
   host, port = db_yaml[env].values_at("host", "port")
-  if service_ready?(host, port || 5432)
+  host ||= "localhost"
+  port ||= 5432
+  if service_ready?(host, port)
     puts "#{host} #{port} - accepting connections"
     true
   else
@@ -26,7 +28,12 @@ def manageiq_db_ready?(db_yaml, env = "production")
   host, port, dbname, password = db_yaml[env].values_at("host", "port", "database", "password")
   password = ManageIQ::Password.try_decrypt(password)
 
-  results = `PGPASSWORD=#{password} psql --host=#{host} --port=#{port || 5432} --dbname=#{dbname} --tuples-only --no-align --command="SELECT COUNT(*) FROM miq_regions"`
+  # If not present, let psql decide to use localhost, socket, etc.
+  host_arg = host.nil?     ? "" : "--host=#{host}"
+  port_arg = port.nil?     ? "" : "--port=#{port}"
+  pass_arg = password.nil? ? "" : "PGPASSWORD=#{password}"
+
+  results = `#{pass_arg} psql #{host_arg} #{port_arg} --dbname=#{dbname} --tuples-only --no-align --command="SELECT COUNT(*) FROM miq_regions"`
   if $?.success? && results.to_i > 0
     puts "#{dbname} is up and running"
     true


### PR DESCRIPTION
This PR will let psql handle missing host/port/password values.  For our ncat call, we previously defaulted a missing port to 5432.  We now do the same for host and default to localhost.

This should resolve an issue where database.yml didn't have a `host` field and we'd see this in the journalctl:

**Before**

```
Sep 01 12:15:29 localhost.localdomain systemd[1]: Starting ManageIQ DB Ready...
Sep 01 12:15:29 localhost.localdomain manageiq-db-ready[6804]:   - not accepting connections
Sep 01 12:15:39 localhost.localdomain manageiq-db-ready[6804]:   - not accepting connections
Sep 01 12:15:49 localhost.localdomain manageiq-db-ready[6804]:   - not accepting connections
Sep 01 12:15:59 localhost.localdomain manageiq-db-ready[6804]:   - not accepting connections
Sep 01 12:16:09 localhost.localdomain manageiq-db-ready[6804]:   - not accepting connections
```

**After**
```
Sep 15 16:39:30 *** systemd[1]: Starting ManageIQ DB Ready...
Sep 15 16:39:30 *** manageiq-db-ready[59889]: localhost 5432 - accepting connections
Sep 15 16:39:30 *** manageiq-db-ready[59889]: vmdb_production is up and running
Sep 15 16:39:30 *** systemd[1]: manageiq-db-ready.service: Succeeded.
Sep 15 16:39:30 *** systemd[1]: Started ManageIQ DB Ready.
```
