### PR TITLE
Add manageiq-messaging-ready script

### DIFF
--- a/COPY/usr/bin/manageiq-messaging-ready
+++ b/COPY/usr/bin/manageiq-messaging-ready
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+require "sd_notify"
+require "manageiq-messaging"
+require "manageiq-password"
+
+def service_ready?(host, port)
+  `ncat #{host} #{port} </dev/null 2>/dev/null`
+  $?.success?
+end
+
+def messaging_ready?(msg_yaml, env = "production")
+  host, port = msg_yaml[env].values_at("hostname", "port")
+  host ||= "localhost"
+  port ||= 9092
+
+  if service_ready?(host, port)
+    puts "#{host} #{port} - accepting connections"
+    true
+  else
+    puts "#{host} #{port} - not accepting connections"
+    false
+  end
+end
+
+def manageiq_msging_ready?(msg_yaml, env = "production")
+  options = msg_yaml[env].symbolize_keys.tap { |key| key[:host] = key.delete(:hostname) }
+  options[:"sasl.password"] = ManageIQ::Password.try_decrypt(options[:"sasl.password"]) if options[:"sasl.password"]
+  options.merge!(:client_ref => "test", :protocol => "Kafka", :encoding => "json")
+
+  # Test broker connection by publishing message to queue and immediately consuming message
+  broker = ManageIQ::Messaging::Client.open(options)
+  broker.publish_message(:service => "test-messaging-ready", :message => "test message", :payload => {})
+  broker.subscribe_messages(:service => "test-messaging-ready") { break }
+rescue => err
+  puts err
+  puts "Kafka is not ready yet"
+  false
+else
+  puts "Kafka is up and running"
+  true
+end
+
+loop do
+  messaging_yaml = YAML.load_file("/var/www/miq/vmdb/config/messaging.yml")
+
+  break if messaging_ready?(messaging_yaml) && manageiq_msging_ready?(messaging_yaml)
+
+  sleep(10)
+end
+
+SdNotify.ready


### PR DESCRIPTION
- script to be used when configuring/upgrading appliance in order to wait until Kafka is ready, in a similar fashion to `manageiq-db-ready`

```
[root@icp-312-reg032019-worker-5 ~]# systemctl status manageiq-messaging-ready
● manageiq-messaging-ready.service - ManageIQ Messaging Ready
   Loaded: loaded (/usr/lib/systemd/system/manageiq-messaging-ready.service; disabled; vendor preset: disabled)
   Active: inactive (dead) since Mon 2022-09-19 14:58:42 EDT; 13min ago
  Process: 103394 ExecStart=/usr/bin/manageiq-messaging-ready (code=exited, status=0/SUCCESS)
 Main PID: 103394 (code=exited, status=0/SUCCESS)

Sep 19 14:58:40 icp-312-reg032019-worker-5.rtp.raleigh.ibm.com systemd[1]: Starting ManageIQ Messaging Ready...
Sep 19 14:58:42 icp-312-reg032019-worker-5.rtp.raleigh.ibm.com manageiq-messaging-ready[103394]: icp-312-reg032019-worker-5.rtp.raleigh.ibm.com 9093 - accepting connections
Sep 19 14:58:42 icp-312-reg032019-worker-5.rtp.raleigh.ibm.com manageiq-messaging-ready[103394]: {:port=>9093, :"sasl.mechanism"=>"PLAIN", :"sasl.username"=>"admin", :"sasl.password"=>"smartvm", :"security.protocol"=>"SASL_SSL", :"ssl.ca.location"=>"/opt/kafka/config/key>
Sep 19 14:58:42 icp-312-reg032019-worker-5.rtp.raleigh.ibm.com manageiq-messaging-ready[103394]: Kafka is up and running
Sep 19 14:58:42 icp-312-reg032019-worker-5.rtp.raleigh.ibm.com systemd[1]: manageiq-messaging-ready.service: Succeeded.
Sep 19 14:58:42 icp-312-reg032019-worker-5.rtp.raleigh.ibm.com systemd[1]: Started ManageIQ Messaging Ready.
```

Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/22113

@miq-bot add_label enhancement
@miq-bot assign @agrare 