### PR TITLE
Change default localhost to 127.0.0.1 in manageiq-messaging-ready

### DIFF
--- a/COPY/usr/bin/manageiq-messaging-ready
+++ b/COPY/usr/bin/manageiq-messaging-ready
@@ -12,7 +12,7 @@ end
 
 def messaging_ready?(msg_yaml, env = "production")
   host, port = msg_yaml[env].values_at("hostname", "port")
-  host ||= "localhost"
+  host ||= "127.0.0.1"
   port ||= 9092
 
   if service_ready?(host, port)


### PR DESCRIPTION
- switching to 127.0.0.1 as the default value due to Kafka SSL handshake failures with localhost

@miq-bot assign @agrare 
@miq-bot add_label bug