### PR TITLE
tailmiq and apstatus learned to systemd

### DIFF
--- a/COPY/etc/profile.d/evm.sh
+++ b/COPY/etc/profile.d/evm.sh
@@ -9,9 +9,9 @@ alias vmdb='cd /var/www/miq/vmdb'
 alias appliance='[[ -n ${APPLIANCE_SOURCE_DIRECTORY} ]] && cd ${APPLIANCE_SOURCE_DIRECTORY}'
 
 # Tail Logs:
-function tailmiq() #If no value is given with tailmiq it defaults to the evm.log
+function tailmiq() # If no value is given with tailmiq it defaults to the manageiq* and evm* units
 {
-  tail -f /var/www/miq/vmdb/log/${1:-evm}.log
+  journalctl -f -u ${1:-manageiq* -u evm*}
 }
 alias tailpglog='tail -f $APPLIANCE_PG_DATA/pg_log/postgresql.log'
 

--- a/COPY/etc/profile.d/evm.sh
+++ b/COPY/etc/profile.d/evm.sh
@@ -16,6 +16,5 @@ function tailmiq() # If no value is given with tailmiq it defaults to the manage
 alias tailpglog='tail -f $APPLIANCE_PG_DATA/pg_log/postgresql.log'
 
 # Appliance Status:
-alias apstatus='echo;systemctl status evmserverd -n 0;echo; \
-systemctl status httpd.service -n 0;echo;systemctl status memcached -n 0; \
+alias apstatus='systemctl status --no-pager evmserverd manageiq.slice httpd memcached postgresql repmgr* -n 0; \
 echo -e "\nPostgreSQL service:"; pg_isready'


### PR DESCRIPTION
* tailmiq learned to use journalctl

    The only logs that are written in the log directory now are appliance_console,
    vmstat and top_output.  All the rest use journalctl and even the others should
    move over.

* This change makes tailmiq use journalctl with the relevant systemd units.

    Add missing units to systemctl status, remove paging

If needed, I can split these two commits apart but I was here and tested them out and they seem relevant to each other.

