### PR TITLE
manageiq-db-ready script tries (and fails) to log as root into DB

### DIFF
--- a/COPY/usr/bin/manageiq-db-ready
+++ b/COPY/usr/bin/manageiq-db-ready
@@ -23,10 +23,10 @@ def database_ready?(db_yaml, env = "production")
 end
 
 def manageiq_db_ready?(db_yaml, env = "production")
-  host, port, dbname, password = db_yaml[env].values_at("host", "port", "database", "password")
+  host, port, dbname, password, username = db_yaml[env].values_at("host", "port", "database", "password", "username")
   password = ManageIQ::Password.try_decrypt(password)
 
-  results = `PGPASSWORD=#{password} psql --host=#{host} --port=#{port || 5432} --dbname=#{dbname} --tuples-only --no-align --command="SELECT COUNT(*) FROM miq_regions"`
+  results = `PGPASSWORD=#{password} psql -U #{username || 'root'} --host=#{host} --port=#{port || 5432} --dbname=#{dbname} --tuples-only --no-align --command="SELECT COUNT(*) FROM miq_regions"`
   if $?.success? && results.to_i > 0
     puts "#{dbname} is up and running"
     true


### PR DESCRIPTION
Note, this PR replaces https://github.com/ManageIQ/manageiq-appliance/pull/375

manageiq-db-ready script tries (and fails) to log as root into DB in case when different username is set in MIQ configuration yaml

database.yaml generated from appliance console:
`...
production:
  adapter: postgresql
  encoding: utf8
  username: miq_own
  pool: 5
  wait_timeout: 5
  min_messages: warning
  database: miq
  host: P013TT01
  port: 5432
  password: ***********
...
`


`psql: error: FATAL:  LDAP authentication failed for user "root"
`