### PR TITLE
pg_log changed to log in postgres 10 as default log directory

### DIFF
--- a/COPY/etc/profile.d/evm.sh
+++ b/COPY/etc/profile.d/evm.sh
@@ -13,7 +13,7 @@ function tailmiq() # If no value is given with tailmiq it defaults to the manage
 {
   journalctl -f -u ${1:-manageiq* -u evm*}
 }
-alias tailpglog='tail -f $APPLIANCE_PG_DATA/pg_log/postgresql.log'
+alias tailpglog='tail -f $APPLIANCE_PG_DATA/log/postgresql.log'
 
 # Appliance Status:
 alias apstatus='systemctl status --no-pager evmserverd manageiq.slice httpd memcached postgresql repmgr* -n 0; \

--- a/manageiq-setup.sh
+++ b/manageiq-setup.sh
@@ -31,9 +31,9 @@ semodule -r cockpit_ws_miq || true
 [ -x /sbin/restorecon ] && /sbin/restorecon -R -v ${APPLIANCE_SOURCE_DIRECTORY}/logrotate_free_space_check.sh
 [ -x /sbin/restorecon ] && /sbin/restorecon -R -v /usr/bin
 
-# relabel the pg_log directory in postgresql datadir, but defer restorecon
+# relabel the log directory in postgresql datadir, but defer restorecon
 # until after the database is initialized during firstboot configuration
-/usr/sbin/semanage fcontext -a -t var_log_t "${APPLIANCE_PG_DATA}/pg_log(/.*)?"
+/usr/sbin/semanage fcontext -a -t var_log_t "${APPLIANCE_PG_DATA}/log(/.*)?"
 
 # setup label for postgres client certs, but relabel after dir is created
 /usr/sbin/semanage fcontext -a -t cert_t "/root/.postgresql(/.*)?"


### PR DESCRIPTION
https://www.postgresql.org/docs/9.6/runtime-config-logging.html

log_directory (string)
When logging_collector is enabled, this parameter determines the directory in which log files will be created. It can be specified as an absolute path, or relative to the cluster data directory. This parameter can only be set in the postgresql.conf file or on the server command line. The default is pg_log.

vs.

https://www.postgresql.org/docs/10/runtime-config-logging.html#RUNTIME-CONFIG-LOGGING-WHERE log_directory (string)
When logging_collector is enabled, this parameter determines the directory in which log files will be created. It can be specified as an absolute path, or relative to the cluster data directory. This parameter can only be set in the postgresql.conf file or on the server command line. The default is log.

It remains the same in postgresql 13.

See also:
https://github.com/ManageIQ/manageiq/pull/22747