### PR TITLE
Rework Kafka health check in manageiq-messaging-ready

### DIFF
--- a/COPY/usr/bin/manageiq-messaging-ready
+++ b/COPY/usr/bin/manageiq-messaging-ready
@@ -32,6 +32,7 @@ def manageiq_msging_ready?(msg_yaml, env = "production")
   broker = ManageIQ::Messaging::Client.open(options)
   broker.publish_message(:service => "manageiq.liveness-check", :message => "test message", :payload => {})
   broker.subscribe_messages(:service => "manageiq.liveness-check") { break }
+  broker.close
 rescue => err
   puts err
   puts "Kafka is not ready yet"

--- a/COPY/usr/bin/manageiq-messaging-ready
+++ b/COPY/usr/bin/manageiq-messaging-ready
@@ -28,11 +28,9 @@ def manageiq_msging_ready?(msg_yaml, env = "production")
   options[:password] = ManageIQ::Password.try_decrypt(options[:password]) if options[:password]
   options[:client_ref] = "manageiq-messaging-ready"
 
-  # Test broker connection by publishing message to queue and immediately consuming message
+  # Test broker connection by listing topics
   broker = ManageIQ::Messaging::Client.open(options)
-  broker.publish_message(:service => "manageiq.liveness-check", :message => "test message", :payload => {})
-  broker.subscribe_messages(:service => "manageiq.liveness-check") { break }
-  broker.close
+  broker.topics
 rescue => err
   puts err
   puts "Kafka is not ready yet"
@@ -40,6 +38,8 @@ rescue => err
 else
   puts "Kafka is up and running"
   true
+ensure
+  broker&.close
 end
 
 def initialize_topics(msg_yaml, env = "production")


### PR DESCRIPTION
- The push/pop approach for Kafka health checks is not ideal because this can lead to timing issues when dealing with multiple consumers (multiple appliances). Therefore using a simple call to retrieve metadata from the Kafka server, this will fail if the server is down which is ideal for a health check
-  Kafka client connections should be closed to prevent issues with multiple consumers on the same topic

Depends on:
- [x] https://github.com/ManageIQ/manageiq-messaging/pull/88
- [x] https://github.com/ManageIQ/manageiq/pull/23020
- [x] https://github.com/ManageIQ/manageiq-messaging/pull/89

@miq-bot assign @agrare 
@miq-bot add_reviewers @agrare 
@miq-bot add_label bug

