### PR TITLE
Move TERRAFORM_RUNNER_URL to appliance specific properties

### DIFF
--- a/COPY/etc/default/manageiq-appliance.properties
+++ b/COPY/etc/default/manageiq-appliance.properties
@@ -1,0 +1,2 @@
+# Opentofu runner endpoint
+TERRAFORM_RUNNER_URL=https://localhost:6000

--- a/COPY/etc/default/manageiq.properties
+++ b/COPY/etc/default/manageiq.properties
@@ -43,6 +43,3 @@ RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 # Ansible global variables
 ANSIBLE_LOCAL_TEMP=/tmp/.ansible_local_tmp
 ANSIBLE_REMOTE_TEMP=/tmp/.ansible_remote_tmp
-
-# Opentofu runner endpoint
-TERRAFORM_RUNNER_URL=https://localhost:6000


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-appliance/pull/385

I didn't realize that /etc/default/manageiq.properties was also present on podified (since it was in manageiq-appliance repo :laughing:)

This adds an appliance-specific properties file which we can package only in the appliance rpm

Follow-up:
* RPM build changes to only install this file on appliances https://github.com/ManageIQ/manageiq-rpm_build/pull/464
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
