### PR TITLE
Add sudo rules for LVM commands for manageiq user

### DIFF
--- a/COPY/etc/sudoers.d/lvm
+++ b/COPY/etc/sudoers.d/lvm
@@ -1,0 +1,2 @@
+Defaults:manageiq !requiretty
+manageiq ALL = NOPASSWD: /usr/sbin/lvchange, /usr/sbin/lvs


### PR DESCRIPTION
During SSA scans on an appliance, there are certain scenarios where the manageiq user may need to use lvm commands to activate LVs. These rules will allow for workarounds that will help get past these scenarios

Related:
- [x] https://github.com/ManageIQ/manageiq-smartstate/pull/189
- [x] https://github.com/ManageIQ/manageiq-rpm_build/pull/471

@miq-bot assign @agrare
@miq-bot add_reviewer @agrare, @Fryguy 
@miq-bot add_label enhancement
