### PR TITLE
default encryption to scram-sha-256

### DIFF
--- a/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
+++ b/COPY/etc/manageiq/postgresql.conf.d/01_miq_overrides.conf
@@ -15,6 +15,7 @@ max_connections = 1000
 
 unix_socket_group = 'postgres'
 unix_socket_permissions = 0770
+password_encryption = scram-sha-256
 
 ssl = on
 


### PR DESCRIPTION
for versions before 14, this was defaulting to md5

Compatibility grid
----

|postgresql.conf|pg_hba.conf|password|works|
|------|-----|-----|----|
|   `md5`|`trust`|  `md5`| ✅|  
|   `md5`|  `md5`|  `md5`| ✅|
|   `md5`|`scram`|  `md5`| 🚫|
| `scram`|  `md5`|  `md5`| ✅|
| `scram`|`md5`  |`scram`| ✅|
| `scram`|`scram`|`scram`| ✅|

Verbose Walkthrough
-----

1. change pg_hba.conf to md5 (it was trust)
  - login as postgres:postgres - works
2. change pg_hba.conf to scram-sha-256
  - psql: error: FATAL:  password authentication failed for user "postgres"
3. change `postgresql.conf` to `scram-sha-256` and change `pg_hba.conf` to `md5`
  - login works (note: my password is still stored as md5 )
4. upgrade my password via `\password`

```
SELECT rolname,
       CASE WHEN rolpassword IS NULL THEN 'no password'
            WHEN rolpassword ~ '^SCRAM-SHA-256\$' THEN 'upgraded'
            ELSE 'please upgrade' END AS has_upgraded
FROM pg_authid
WHERE rolcanlogin;
```

 rolname  |  has_upgraded
----------|----------------
 root     | no password
 kbrock   | no password
 postgres | please upgrade

- login works (note: pg_hba.conf is md5 but my password is scram
5. change pg_hba.conf to scram-sha-256
- login works
