### PR TITLE
Workaround issue where activated base64 isn't what's in bundle

### DIFF
--- a/COPY/etc/profile.d/evm.sh
+++ b/COPY/etc/profile.d/evm.sh
@@ -8,6 +8,10 @@ alias apcli='appliance_console_cli'
 alias vmdb='cd /var/www/miq/vmdb'
 alias appliance='[[ -n ${APPLIANCE_SOURCE_DIRECTORY} ]] && cd ${APPLIANCE_SOURCE_DIRECTORY}'
 
+# Define an alias to override any rubygems binstubs
+# to ensure it's run through the application's bundle.
+alias appliance_console='bundle exec appliance_console'
+
 # Tail Logs:
 function tailmiq() # If no value is given with tailmiq it defaults to the manageiq* and evm* units
 {


### PR DESCRIPTION
We were activating a 0.2.0 version first, then trying to load the bundle,
which includes 0.1.2.  This fails with:

"You have already activated base64 0.2.0, but your Gemfile requires base64 0.1.2.
Since base64 is a default gem, you can either remove your dependency on it or
try updating to a newer version of bundler that supports base64 as a default gem."

Perhaps the change is that activesupport 7.1 added base64
as a direct dependency.

See:
https://rubygems.org/gems/activesupport/versions/7.1.5.1
vs.
https://rubygems.org/gems/activesupport/versions/7.0.8.7

An alternative is to add another binstub earlier in the $PATH paths.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
