### PR TITLE
Check for pending migrations before starting MIQ

### DIFF
--- a/COPY/usr/bin/manageiq-db-ready
+++ b/COPY/usr/bin/manageiq-db-ready
@@ -36,11 +36,22 @@ def manageiq_db_ready?(db_yaml, env = "production")
   end
 end
 
+def manageiq_db_migrations_current?
+  system("bin/rake db:abort_if_pending_migrations", :chdir => "/var/www/miq/vmdb")
+  if $?.success?
+    puts "migrations are up to date"
+    true
+  else
+    puts "there are pending migrations, run bin/rake db:migrate"
+    false
+  end
+end
+
 loop do
   # reload the database yaml in case it changes between checks
   database_yml = YAML.load_file("/var/www/miq/vmdb/config/database.yml")
 
-  break if database_ready?(database_yml) && manageiq_db_ready?(database_yml)
+  break if database_ready?(database_yml) && manageiq_db_ready?(database_yml) && manageiq_db_migrations_current?
 
   sleep(10)
 end


### PR DESCRIPTION
If there are migrations pending we should wait to start evmserverd until the user runs those migrations.

```
$ bin/rake db:abort_if_pending_migrations
** ManageIQ master, codename: Tal
You have 1 pending migration:
  20250214153835 MoveBlacklistedEventsToSettingsChanges
Run `bin/rails db:migrate` to update your database then try again.
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
