### PR TITLE
Set OIDCCacheShmMax value to avoid using changed package defaults

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
@@ -9,6 +9,7 @@ OIDCRedirectURI                    https://<%= miq_appliance %>/oidc_login/redir
 OIDCCryptoPassphrase               sp-cookie
 OIDCOAuthRemoteUserClaim           username
 OIDCCacheShmEntrySizeMax           65536
+OIDCCacheShmMax                    500
 OIDCOAuthClientID                  <%= oidc_client_id %>
 OIDCOAuthClientSecret              <%= oidc_client_secret %>
 OIDCOAuthIntrospectionEndpoint     <%= oidc_introspection_endpoint %>


### PR DESCRIPTION
Packages upgraded from:
mod_auth_openidc-2.4.10-1.el9_6.2.ppc64le

To:
mod_auth_openidc-2.4.16.11-1.el9.ppc64le

Similar upgrades occurred on x86_64.

In v2.4.13, they changed the OIDC_DEFAULT_CACHE_SHM_SIZE from 500 to 2000: https://github.com/OpenIDC/mod_auth_openidc/commit/dec66b7a43f5a1a0324a7dda4965918a4eef2ea1 OIDC_MINIMUM_CACHE_SHM_ENTRY_SIZE_MAX was removed (previously:  8192+512+17)

In, v2.4.14, they changed OIDC_DEFAULT_CACHE_SHM_SIZE from 2000 to 10000: https://github.com/OpenIDC/mod_auth_openidc/commit/5990854b25cc5c8445aecdb1a57c1403027b36a6

On power, our page size is larger so this impacted memory usage tremendously. We saw memory usage go from 70-80 MB to over 600 MB on power.

This change puts back the prior value from 2.4.10.  We can address changing these values specifically for power or othe platforms later on.

Containers change in https://github.com/ManageIQ/manageiq-pods/pull/1320

Fixes: https://jsw.ibm.com/browse/CP4AIOPS-21936

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
