### PR TITLE
Set hsts by default

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -12,6 +12,7 @@ Include conf.d/manageiq-redirects-ui
 Include conf.d/manageiq-redirects-websocket
 Include conf.d/manageiq-host-config
 RequestHeader set X_FORWARDED_PROTO 'https'
+Header always set Strict-Transport-Security "max-age=631138519"
 
 ErrorLog /var/www/miq/vmdb/log/apache/ssl_error.log
 TransferLog /var/www/miq/vmdb/log/apache/ssl_access.log
@@ -24,6 +25,7 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 
 <Location /assets/>
   Header unset ETag
+  Header always set Strict-Transport-Security   "max-age=631138519"
   Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self'; font-src 'self' fonts.gstatic.com; script-src 'self'; style-src 'self'; report-uri /dashboard/csp_report"
   Header set X-Content-Type-Options             "nosniff"
   Header set X-Frame-Options                    "SAMEORIGIN"
@@ -37,6 +39,7 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 
 <Location /packs/>
   Header unset ETag
+  Header always set Strict-Transport-Security   "max-age=631138519"
   Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self'; font-src 'self' fonts.gstatic.com; script-src 'self'; style-src 'self'; report-uri /dashboard/csp_report"
   Header set X-Content-Type-Options             "nosniff"
   Header set X-Frame-Options                    "SAMEORIGIN"

--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -23,8 +23,9 @@ SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
 SSLCertificateFile /var/www/miq/vmdb/certs/server.cer
 SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
 
-<Location /assets/>
+<LocationMatch "^/(assets|packs)/">
   Header unset ETag
+  # Explicit HSTS needed: Location blocks using "Header set" don't inherit "Header always set" from VirtualHost
   Header always set Strict-Transport-Security   "max-age=631138519"
   Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self'; font-src 'self' fonts.gstatic.com; script-src 'self'; style-src 'self'; report-uri /dashboard/csp_report"
   Header set X-Content-Type-Options             "nosniff"
@@ -35,21 +36,7 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
   Header merge Cache-Control public
   ExpiresActive On
   ExpiresDefault "access plus 1 year"
-</Location>
-
-<Location /packs/>
-  Header unset ETag
-  Header always set Strict-Transport-Security   "max-age=631138519"
-  Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self'; font-src 'self' fonts.gstatic.com; script-src 'self'; style-src 'self'; report-uri /dashboard/csp_report"
-  Header set X-Content-Type-Options             "nosniff"
-  Header set X-Frame-Options                    "SAMEORIGIN"
-  Header set X-Permitted-Cross-Domain-Policies  "none"
-  Header set X-XSS-Protection                   "1; mode=block"
-  FileETag None
-  Header merge Cache-Control public
-  ExpiresActive On
-  ExpiresDefault "access plus 1 year"
-</Location>
+</LocationMatch>
 
 <Files ~ "\.(cgi|shtml|phtml|php3?)$">
   SSLOptions +StdEnvVars


### PR DESCRIPTION
* Ensure all apache requests set Strict-Transport-Security headers.

* Consolidate identical assets|packs locations
These were separated at one time but seemingly always identical.

It wasn't a big deal when it was 5 lines each but now it's double and pointless
to make the same change in multiple places.

See also: https://github.com/ManageIQ/manageiq-appliance/pull/191

CP4AIOPS-447

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
