### PR TITLE
 Security headers csp cleanup

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -30,7 +30,8 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
   Header always set Strict-Transport-Security   "max-age=631138519"
   # CSP for static assets: includes directives that differ from default-src 'self' and
   # directives that do not fall back to default-src (base-uri, form-action, frame-ancestors)
-  Header set Content-Security-Policy            "default-src 'self'; base-uri 'self'; child-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report"
+  Header set Content-Security-Policy            "default-src 'self'; base-uri 'self'; child-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report; report-to csp-endpoint"
+  Header set Report-To                          "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"/dashboard/csp_report\"}]}"
   Header set X-Content-Type-Options             "nosniff"
   Header set X-Frame-Options                    "SAMEORIGIN"
   Header set X-Permitted-Cross-Domain-Policies  "none"

--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -28,8 +28,9 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
   Header unset ETag
   # Explicit HSTS needed: Location blocks using "Header set" don't inherit "Header always set" from VirtualHost
   Header always set Strict-Transport-Security   "max-age=631138519"
-  # Minimal CSP for static assets: only specifies directives that differ from default-src 'self'
-  Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report"
+  # CSP for static assets: includes directives that differ from default-src 'self' and
+  # directives that do not fall back to default-src (base-uri, form-action, frame-ancestors)
+  Header set Content-Security-Policy            "default-src 'self'; base-uri 'self'; child-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report"
   Header set X-Content-Type-Options             "nosniff"
   Header set X-Frame-Options                    "SAMEORIGIN"
   Header set X-Permitted-Cross-Domain-Policies  "none"

--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -28,7 +28,8 @@ SSLCertificateKeyFile /var/www/miq/vmdb/certs/server.cer.key
   Header unset ETag
   # Explicit HSTS needed: Location blocks using "Header set" don't inherit "Header always set" from VirtualHost
   Header always set Strict-Transport-Security   "max-age=631138519"
-  Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; connect-src 'self'; font-src 'self' fonts.gstatic.com; script-src 'self'; style-src 'self'; report-uri /dashboard/csp_report"
+  # Minimal CSP for static assets: only specifies directives that differ from default-src 'self'
+  Header set Content-Security-Policy            "default-src 'self'; child-src 'self'; frame-src 'self'; worker-src 'self'; font-src 'self' fonts.gstatic.com fonts.googleapis.com; img-src 'self' data:; style-src 'self' fonts.googleapis.com fonts.gstatic.com; report-uri /dashboard/csp_report"
   Header set X-Content-Type-Options             "nosniff"
   Header set X-Frame-Options                    "SAMEORIGIN"
   Header set X-Permitted-Cross-Domain-Policies  "none"


### PR DESCRIPTION
* Add report-to and Report-To header for modern CSP reporting (as discussed in https://github.com/ManageIQ/manageiq-pods/pull/1348#discussion_r2855315396)
* Add missing CSP directives that do not fall back to default-src: CP4AIOPS-15067
* Update static asset CSP: add fonts, data: images, frame-src, worker-src

- [x] (Review/merge after rebase of https://github.com/ManageIQ/manageiq-appliance/pull/404)
- [x] Still need to verify on an appliance