### PR TITLE
Add X-Content-Type-Options header globally in VirtualHost

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -13,6 +13,7 @@ Include conf.d/manageiq-redirects-websocket
 Include conf.d/manageiq-host-config
 RequestHeader set X_FORWARDED_PROTO 'https'
 Header always set Strict-Transport-Security "max-age=631138519"
+Header always set X-Content-Type-Options "nosniff"
 
 ErrorLog /var/www/miq/vmdb/log/apache/ssl_error.log
 TransferLog /var/www/miq/vmdb/log/apache/ssl_access.log


### PR DESCRIPTION
Set X-Content-Type-Options: nosniff at the VirtualHost level to ensure all responses (including /custom.css and /robots.txt) have the header, not just assets under /assets and /packs paths.

CP4AIOPS-448

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
