### PR TITLE
We don't want to change ownership of /var/www/miq/vmdb/tmp/pids

### DIFF
--- a/COPY/usr/bin/miqtop.sh
+++ b/COPY/usr/bin/miqtop.sh
@@ -11,7 +11,6 @@ PID_FILE=${PID_DIR}/top.pid
 ### Attempt to create pid and log directores in case they do not exist ###
 mkdir -p ${PID_DIR}
 mkdir -p ${LOG_DIR}
-chown ${USER}:${USER} ${PID_DIR} ${LOG_DIR}
 
 ### If an instance of top(1) in running, do not start another. ###
 if [ -e ${PID_FILE} ]

--- a/COPY/usr/bin/miqvmstat.sh
+++ b/COPY/usr/bin/miqvmstat.sh
@@ -11,7 +11,6 @@ PID_FILE=${PID_DIR}/vmstat.pid
 ### Attempt to create pid and log directores in case they do not exist ###
 mkdir -p ${PID_DIR}
 mkdir -p ${LOG_DIR}
-chown ${USER}:${USER} ${PID_DIR} ${LOG_DIR}
 
 ### If an instance of vmstat(1) in running, do not start another. ###
 if [ -e ${PID_FILE} ]


### PR DESCRIPTION
When these services started, they would change the ownership of the directories from manageiq:manageiq to root:root which would prevent application workers from creating pid files, causing them to crash.

I'm not sure why this is working on EL9, I didn't investigate that.

Part of: https://github.com/ManageIQ/manageiq/issues/23737