### PR TITLE
Specify OIDCPassClaimsAs with none for backwards compatibility

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
@@ -13,6 +13,7 @@ OIDCCacheShmMax                    500
 OIDCOAuthClientID                  <%= oidc_client_id %>
 OIDCOAuthClientSecret              <%= oidc_client_secret %>
 OIDCOAuthIntrospectionEndpoint     <%= oidc_introspection_endpoint %>
+OIDCPassClaimsAs                   both none
 OIDCOAuthIntrospectionEndpointAuth client_secret_basic
 OIDCCookieSameSite                 On
 


### PR DESCRIPTION
Fixes an invalid byte sequence when the user/group contains UTF8 characters when tested with 2.4.16+ openidc.

From: https://github.com/OpenIDC/mod_auth_openidc/commit/28e79bf76ab6b4aae286a89452c2c2ceeca36efb

apply ISO-8859-1 as default encoding mechanism for claim values passed in headers and environment variables to comply with https://www.rfc-editor.org/rfc/rfc5987; see #957; use "OIDCPassClaimsAs <any> none" for backwards compatibility; bump to 2.4.15rc3

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
