### PR TITLE
Drop redundant HSTS from OIDC Location blocks

### DIFF
--- a/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
+++ b/TEMPLATE/etc/httpd/conf.d/manageiq-external-auth-openidc.conf.erb
@@ -28,8 +28,6 @@ OIDCCryptoPassphrase               sp-cookie
   AuthType                   openid-connect
   Require                    valid-user
   FileETag                   None
-  Header always set Strict-Transport-Security "max-age=631138519"
-  Header always set X-Content-Type-Options "nosniff"
   Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /dashboard/csp_report; report-to csp-endpoint"
   Header set Report-To       "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"/dashboard/csp_report\"}]}"
   Header Set Cache-Control   "max-age=0, no-store, no-cache, must-revalidate"
@@ -41,8 +39,6 @@ OIDCCryptoPassphrase               sp-cookie
   AuthType                   openid-connect
   Require                    valid-user
   FileETag                   None
-  Header always set Strict-Transport-Security "max-age=631138519"
-  Header always set X-Content-Type-Options "nosniff"
   Header set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; report-uri /dashboard/csp_report; report-to csp-endpoint"
   Header set Report-To       "{\"group\":\"csp-endpoint\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"/dashboard/csp_report\"}]}"
   Header Set Cache-Control   "max-age=0, no-store, no-cache, must-revalidate"


### PR DESCRIPTION
HSTS is already set at the VirtualHost *:443 level in manageiq-https-application.conf, which covers all URLs including /oidc_login and /ui/service/oidc_login. The Location-block copies were duplicating it on OIDC responses. X-Content-Type-Options was also duplicated in the same blocks; remove it here too.

Partial fix for CP4AIOPS-25657; prior related work: 57af24c

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
