### PR TITLE
Drop broken Reporting-Endpoints from Apache VirtualHost

### DIFF
--- a/COPY/etc/httpd/conf.d/manageiq-https-application.conf
+++ b/COPY/etc/httpd/conf.d/manageiq-https-application.conf
@@ -20,8 +20,6 @@ Header always unset Referrer-Policy
 Header always set Referrer-Policy "no-referrer-when-downgrade"
 Header always unset X-Frame-Options
 Header always set X-Frame-Options "SAMEORIGIN"
-Header always unset Reporting-Endpoints
-Header always set Reporting-Endpoints "csp-endpoint=\"https://%{HTTP_HOST}i/dashboard/csp_report\""
 
 ErrorLog /var/www/miq/vmdb/log/apache/ssl_error.log
 TransferLog /var/www/miq/vmdb/log/apache/ssl_access.log


### PR DESCRIPTION
`%{HTTP_HOST}e` (38dc44a, CP4AIOPS-31150) and `%{HTTP_HOST}i` (d495107) both fail in Apache 2.4.63 on RHEL -- neither env-var nor incoming-header mod_headers specifiers are populated at `VirtualHost Header always set` level in this build. Tested in a running httpd pod: both produce (null) or i=98 regardless of placement (VirtualHost level or inside Location).

Drop the header rather than emit a broken URL. CSP violation reports continue to work via the relative report-uri /dashboard/csp_report fallback already present in the Rails CSP directive -- browsers resolve that path against the page origin, so no hostname is needed.

Unlike manageiq-pods and the install-operator where the operator bakes the hostname in via Go fmt.Sprintf before Apache parses the config, manageiq-https-application.conf is a static file with no render step. The correct fix requires a boot script to write a Define before Apache starts, e.g.:

```
  # generate_httpd_hostname_conf.sh (run before httpd starts):
  echo "Define MIQ_HOSTNAME $(hostname -f)" > /etc/httpd/conf.d/miq-hostname.conf

  # manageiq-https-application.conf:
  Header always set Reporting-Endpoints "csp-endpoint=\"https://${MIQ_HOSTNAME}/dashboard/csp_report\""
```

Apache's ${VAR} syntax expands Defines at parse time, same mechanism the guides repo uses with HTTPD_AUTH_HOST passed via container -e flag. Tracked as a follow-up requiring coordination with the boot sequence.

Fixes CP4AIOPS-31150; prior related work: 38dc44a, d495107

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
